### PR TITLE
Harden RLM root response handling and logging

### DIFF
--- a/src/agents/react-agent.ts
+++ b/src/agents/react-agent.ts
@@ -1004,6 +1004,10 @@ notifications = false
 				total_output_chars: result.stats.totalOutputChars,
 				final_set: result.stats.finalSet,
 				fallback_recovery_used: result.stats.fallbackRecoveryUsed,
+				metadata_history_entries: result.metadataHistory.length,
+				last_error:
+					result.metadataHistory[result.metadataHistory.length - 1]?.environment.error
+						?.message ?? null,
 			});
 			return result.answer;
 		}

--- a/src/agents/rlm-orchestrator.ts
+++ b/src/agents/rlm-orchestrator.ts
@@ -46,6 +46,11 @@ export interface RlmRunResult {
   metadataHistory: RlmMetadata[];
 }
 
+interface ExtractedRootCode {
+  code: string;
+  source: "repl" | "js";
+}
+
 export class RlmOrchestrator {
   private readonly config: Required<
     Pick<
@@ -125,14 +130,16 @@ export class RlmOrchestrator {
       throw new Error("RLM orchestrator requires either llmConfig or rootModelQuery");
     }
 
-    this.rootModelQuery = createRootModelQuery(
+    const query = createRootModelQuery(
       this.config.llmConfig,
       this.config.systemPrompt,
-      (inputChars, outputChars) => {
-        this.stats.totalInputChars += inputChars;
-        this.stats.totalOutputChars += outputChars;
-      },
     );
+    this.rootModelQuery = async (history) => {
+      this.stats.totalInputChars += history.length;
+      const text = await query(history);
+      this.stats.totalOutputChars += text.length;
+      return text;
+    };
     return this.rootModelQuery;
   }
 
@@ -167,15 +174,18 @@ export class RlmOrchestrator {
       throw new Error("RLM orchestrator requires either llmConfig or subModelQuery");
     }
 
-    this.subModelQuery = createSubModelQuery(
+    const query = createSubModelQuery(
       this.config.llmConfig,
       undefined,
-      (inputChars, outputChars) => {
-        this.stats.subModelCalls += 1;
-        this.stats.totalInputChars += inputChars;
-        this.stats.totalOutputChars += outputChars;
-      },
     );
+    this.subModelQuery = async (instruction, data) => {
+      this.stats.subModelCalls += 1;
+      const prompt = `Instruction:\n${instruction}\n\nData:\n${data}`;
+      this.stats.totalInputChars += prompt.length;
+      const text = await query(instruction, data);
+      this.stats.totalOutputChars += text.length;
+      return text;
+    };
     return this.subModelQuery;
   }
 
@@ -236,6 +246,28 @@ export class RlmOrchestrator {
     return parts.join("\n");
   }
 
+  private createEnvironmentError(
+    kind: EnvironmentErrorPayload["kind"],
+    code: string,
+    message: string,
+    details?: Record<string, unknown>,
+  ): EnvironmentErrorPayload {
+    return {
+      kind,
+      code,
+      message,
+      ...(details ? { details } : {}),
+    };
+  }
+
+  private previewText(text: string, maxLength = 500): string {
+    if (text.length <= maxLength) {
+      return text;
+    }
+
+    return `${text.slice(0, maxLength)}...`;
+  }
+
   private buildHistory(query: string): string {
     if (!this.rootMetadata) {
       throw new Error("Root metadata must be loaded before building history");
@@ -284,18 +316,24 @@ export class RlmOrchestrator {
     return parts.join("\n\n---\n\n");
   }
 
-  private extractCodeFromResponse(response: string): string {
+  private extractCodeFromResponse(response: string): ExtractedRootCode | null {
     const replMatch = response.match(/```repl\s*([\s\S]*?)```/);
     if (replMatch?.[1]) {
-      return replMatch[1].trim();
+      return {
+        code: replMatch[1].trim(),
+        source: "repl",
+      };
     }
 
     const jsMatch = response.match(/```(?:javascript|js|ts|typescript)\s*([\s\S]*?)```/);
     if (jsMatch?.[1]) {
-      return jsMatch[1].trim();
+      return {
+        code: jsMatch[1].trim(),
+        source: "js",
+      };
     }
 
-    return response.trim();
+    return null;
   }
 
   private async runChild(task: SubRlmRequest): Promise<SubRlmResult> {
@@ -422,6 +460,13 @@ export class RlmOrchestrator {
       for (let iteration = 1; iterationBudget.remaining > 0; iteration++) {
         const history = this.buildHistory(query);
         iterationBudget.remaining -= 1;
+        logger.debug("RLM", "Root iteration started", {
+          iteration,
+          historyLength: history.length,
+          metadataHistoryLength: this.metadataHistory.length,
+          remainingIterationBudget: iterationBudget.remaining,
+          lastError: this.lastError ?? null,
+        });
         let codeResponse: string;
         try {
           codeResponse = await this.getRootModelQuery()(history);
@@ -429,6 +474,11 @@ export class RlmOrchestrator {
           const message =
             error instanceof Error ? error.message : String(error);
           this.lastError = message;
+          logger.warn("RLM", "Root model query failed", {
+            iteration,
+            historyLength: history.length,
+            error: message,
+          });
           this.metadataHistory.push({
             iteration,
             environment: {
@@ -450,11 +500,74 @@ export class RlmOrchestrator {
           this.stats.rootIterations += 1;
           continue;
         }
-        const code = this.extractCodeFromResponse(codeResponse);
+        logger.debug("RLM", "Root model response received", {
+          iteration,
+          responseLength: codeResponse.length,
+          hasReplFence: codeResponse.includes("```repl"),
+          hasJavaScriptFence: /```(?:javascript|js|ts|typescript)/.test(codeResponse),
+          responsePreview: this.previewText(codeResponse),
+        });
+
+        const extracted = this.extractCodeFromResponse(codeResponse);
+        if (!extracted) {
+          const error = this.createEnvironmentError(
+            "llm",
+            "ROOT_MODEL_RESPONSE_FORMAT_INVALID",
+            "Root model response must include a fenced repl/javascript/typescript code block.",
+            {
+              iteration,
+              responsePreview: this.previewText(codeResponse),
+            },
+          );
+
+          this.lastError = error.message;
+          this.metadataHistory.push({
+            iteration,
+            environment: {
+              stdoutPreview: "",
+              stdoutLength: 0,
+              variableCount: 0,
+              variables: [],
+              bufferKeys: [],
+              finalSet: false,
+              error,
+            },
+            errorFeedback:
+              `${error.message} Include a fenced repl code block with executable code. Extra text outside the fence is ignored.`,
+            hasContext: !!this.config.initialContext,
+          });
+          this.stats.rootIterations += 1;
+          logger.warn("RLM", "Root model response rejected", {
+            iteration,
+            code: error.code,
+            responseLength: codeResponse.length,
+            responsePreview: this.previewText(codeResponse),
+          });
+          continue;
+        }
+
+        logger.debug("RLM", "Root model response extracted", {
+          iteration,
+          source: extracted.source,
+          codeLength: extracted.code.length,
+          codePreview: this.previewText(extracted.code),
+        });
+
         const session = await this.ensureSession();
-        const executionResult = await session.execute(code);
+        const executionResult = await session.execute(extracted.code);
 
         this.stats.rootIterations += 1;
+        logger.debug("RLM", "Iteration execution completed", {
+          iteration,
+          stdoutLength: executionResult.metadata.stdoutLength,
+          stdoutPreview: executionResult.metadata.stdoutPreview || "(empty)",
+          variableCount: executionResult.metadata.variableCount,
+          bufferKeys: executionResult.metadata.bufferKeys,
+          finalSet: executionResult.metadata.finalSet,
+          finalSource: executionResult.metadata.finalSource ?? null,
+          errorCode: executionResult.error?.code ?? null,
+          errorMessage: executionResult.error?.message ?? null,
+        });
         this.metadataHistory.push({
           iteration,
           environment: executionResult.metadata,
@@ -472,6 +585,11 @@ export class RlmOrchestrator {
 
         if (executionResult.finalAnswer) {
           this.stats.finalSet = true;
+          logger.info("RLM", "FINAL() captured", {
+            iteration,
+            finalSource: executionResult.metadata.finalSource ?? null,
+            answerPreview: this.previewText(executionResult.finalAnswer, 200),
+          });
           logger.timingEnd(timingId, "RLM", "Orchestrator completed");
           return {
             answer: executionResult.finalAnswer,
@@ -481,6 +599,12 @@ export class RlmOrchestrator {
         }
       }
 
+      logger.warn("RLM", "Root iteration budget exhausted without FINAL()", {
+        rootIterations: this.stats.rootIterations,
+        subRlmCalls: this.stats.subRlmCalls,
+        repoCalls: this.stats.repoCalls,
+        lastError: this.lastError ?? null,
+      });
       const recovered = await this.recoverFinalAnswer(query);
       logger.timingEnd(timingId, "RLM", "Orchestrator recovered");
 

--- a/src/agents/rlm-prompts.ts
+++ b/src/agents/rlm-prompts.ts
@@ -34,13 +34,14 @@ Rules:
 4. Use \`sub_rlm\` only with a structured task object.
 5. The normal success path is \`FINAL()\` or \`FINAL_VAR()\`. Fallback summarization is recovery-only.
 6. Preserve work inside the active environment instead of replaying earlier steps.
+7. Include a fenced \`\`\`repl code block with executable code. Any extra prose, thinking traces, XML tags, or markdown outside the fence will be ignored.
 
 Execution patterns to prefer:
 - linear investigation when you need to inspect files or directories one by one
 - pairwise or quadratic comparison only when the task truly requires comparing pairs
 - recursive decomposition when a sub-problem deserves its own \`sub_rlm\` run
 
-When you answer with code, prefer a \`\`\`repl block.
+When you answer, include a \`\`\`repl block containing the executable code the controller should run.
 
 ${contextBlock}
 

--- a/src/agents/rlm-sandbox.ts
+++ b/src/agents/rlm-sandbox.ts
@@ -154,13 +154,32 @@ async function runGenerateText(
   prompt: string,
 ): Promise<string> {
   const model = createLanguageModel(config);
-  const { text } = await generateText({
-    model,
-    system: systemPrompt,
-    prompt,
-  });
+  try {
+    const { text } = await generateText({
+      model,
+      system: systemPrompt,
+      prompt,
+    });
 
-  return text;
+    logger.debug("LLM", "generateText completed", {
+      provider: config.type,
+      model: config.model || getDefaultModel(config),
+      systemPromptLength: systemPrompt.length,
+      promptLength: prompt.length,
+      outputLength: text.length,
+    });
+
+    return text;
+  } catch (error) {
+    logger.warn("LLM", "generateText failed", {
+      provider: config.type,
+      model: config.model || getDefaultModel(config),
+      systemPromptLength: systemPrompt.length,
+      promptLength: prompt.length,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
 }
 
 export function createRootModelQuery(

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -33,6 +33,20 @@ interface TimingOperation {
   startTime: number;
 }
 
+export function getLogRuntimeLabel(nodeEnv = process.env.NODE_ENV): "test" | "runtime" {
+  return nodeEnv === "test" ? "test" : "runtime";
+}
+
+export function buildLogFilename(
+  timestamp: string,
+  nodeEnv = process.env.NODE_ENV,
+): string {
+  const runtimeLabel = getLogRuntimeLabel(nodeEnv);
+  return runtimeLabel === "test"
+    ? `${timestamp}-librarian-test.log`
+    : `${timestamp}-librarian.log`;
+}
+
 class Logger {
   private static instance: Logger;
   private writer: FileSink | null = null;
@@ -90,7 +104,7 @@ class Logger {
       }
 
       // Log filename
-      const logFilename = `${timestamp}-librarian.log`;
+      const logFilename = buildLogFilename(timestamp);
       const logPath = path.join(logDir, logFilename);
 
       // Create write stream
@@ -98,7 +112,10 @@ class Logger {
       this.writer = logFile.writer();
 
       // Log initialization
-      this.info("LOGGER", `Logging initialized: ${logPath}`);
+      this.info("LOGGER", `Logging initialized: ${logPath}`, {
+        runtimeLabel: getLogRuntimeLabel(),
+        pid: process.pid,
+      });
     } catch {
       // Silent - do nothing on initialization errors
     }

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { buildLogFilename, getLogRuntimeLabel } from "../src/utils/logger.js";
+
+describe("logger filename scoping", () => {
+  it("should mark Bun test runs with a test runtime label", () => {
+    expect(getLogRuntimeLabel("test")).toBe("test");
+    expect(getLogRuntimeLabel("production")).toBe("runtime");
+  });
+
+  it("should generate distinct filenames for test and runtime logs", () => {
+    expect(buildLogFilename("2026-03-11_22-45-12_927", "test")).toBe(
+      "2026-03-11_22-45-12_927-librarian-test.log",
+    );
+    expect(buildLogFilename("2026-03-11_22-45-12_927", "production")).toBe(
+      "2026-03-11_22-45-12_927-librarian.log",
+    );
+  });
+});

--- a/tests/rlm-agent-integration.test.ts
+++ b/tests/rlm-agent-integration.test.ts
@@ -352,6 +352,8 @@ describe("ReactAgent RLM integration", () => {
           total_output_chars: 222,
           final_set: true,
           fallback_recovery_used: false,
+          metadata_history_entries: 0,
+          last_error: null,
         });
       } finally {
         logger.info = originalInfo;

--- a/tests/rlm-orchestrator.test.ts
+++ b/tests/rlm-orchestrator.test.ts
@@ -21,6 +21,10 @@ const rootMetadata: RootRepoMetadata = {
   topLevelEntries: [],
 };
 
+function repl(code: string): string {
+  return `\`\`\`repl\n${code}\n\`\`\``;
+}
+
 describe("RlmOrchestrator", () => {
   let config: RlmOrchestratorConfig;
 
@@ -60,9 +64,9 @@ describe("RlmOrchestrator", () => {
       const mockLlm = jest.fn(async () => {
         callCount += 1;
         if (callCount < 3) {
-          return "print('iteration ' + __iteration__)";
+          return repl("print('iteration ' + __iteration__)");
         }
-        return "FINAL('done')";
+        return repl("FINAL('done')");
       });
 
       const orchestrator = new RlmOrchestrator({
@@ -77,7 +81,7 @@ describe("RlmOrchestrator", () => {
     });
 
     it("should stop iteration when FINAL() is set", async () => {
-      const mockLlm = jest.fn(async () => "FINAL('the answer')");
+      const mockLlm = jest.fn(async () => repl("FINAL('the answer')"));
       const orchestrator = new RlmOrchestrator({
         ...config,
         llmQuery: mockLlm,
@@ -103,9 +107,24 @@ describe("RlmOrchestrator", () => {
       expect(result).toBe("from fence");
     });
 
+    it("should ignore surrounding thinking text when a repl block is present", async () => {
+      const mockLlm = jest.fn(
+        async () =>
+          "<think>I should inspect the repo first</think>\n\n```repl\nFINAL('from wrapped fence')\n```\n\nI used the repl block above.",
+      );
+      const orchestrator = new RlmOrchestrator({
+        ...config,
+        llmQuery: mockLlm,
+      });
+
+      const result = await orchestrator.run("test query");
+
+      expect(result).toBe("from wrapped fence");
+    });
+
     it("should resolve FINAL_VAR() from active session bindings", async () => {
       const mockLlm = jest.fn(
-        async () => "const answer = 'local binding'; FINAL_VAR('answer')",
+        async () => repl("const answer = 'local binding'; FINAL_VAR('answer')"),
       );
       const orchestrator = new RlmOrchestrator({
         ...config,
@@ -123,7 +142,7 @@ describe("RlmOrchestrator", () => {
       const receivedHistories: string[] = [];
       const mockLlm = jest.fn(async (_instruction: string, history: string) => {
         receivedHistories.push(history);
-        return "FINAL('done')";
+        return repl("FINAL('done')");
       });
 
       const orchestrator = new RlmOrchestrator({
@@ -149,9 +168,9 @@ describe("RlmOrchestrator", () => {
         callCount += 1;
         receivedHistories.push(history);
         if (callCount < 3) {
-          return "print('iteration ' + __iteration__)";
+          return repl("print('iteration ' + __iteration__)");
         }
-        return "FINAL('done')";
+        return repl("FINAL('done')");
       });
 
       const orchestrator = new RlmOrchestrator({
@@ -174,9 +193,9 @@ describe("RlmOrchestrator", () => {
       const mockLlm = jest.fn(async () => {
         executionCount += 1;
         if (executionCount === 1) {
-          return "function double(x) { return x * 2; } let counter = 1;";
+          return repl("function double(x) { return x * 2; } let counter = 1;");
         }
-        return "counter = double(counter); FINAL(String(counter))";
+        return repl("counter = double(counter); FINAL(String(counter))");
       });
 
       const orchestrator = new RlmOrchestrator({
@@ -194,17 +213,17 @@ describe("RlmOrchestrator", () => {
     it("should launch a child recursive run and inject its structured result", async () => {
       const mockLlm = jest.fn(async (_instruction: string, history: string) => {
         if (history.includes("Task:\nchild task")) {
-          return "FINAL(context.toUpperCase())";
+          return repl("FINAL(context.toUpperCase())");
         }
 
-        return `
+        return repl(`
           const child = await sub_rlm({
             prompt: "child task",
             context: "from child",
             rootHint: "uppercase the context"
           });
           FINAL(child.finalAnswer);
-        `;
+        `);
       });
 
       const orchestrator = new RlmOrchestrator({
@@ -220,10 +239,10 @@ describe("RlmOrchestrator", () => {
     it("should isolate child buffers from the parent session", async () => {
       const mockLlm = jest.fn(async (_instruction: string, history: string) => {
         if (history.includes("Task:\ninspect child isolation")) {
-          return "FINAL(String(buffers.parentBuffer))";
+          return repl("FINAL(String(buffers.parentBuffer))");
         }
 
-        return `
+        return repl(`
           buffers.parentBuffer = "from-parent";
           const child = await sub_rlm({
             prompt: "inspect child isolation",
@@ -231,7 +250,7 @@ describe("RlmOrchestrator", () => {
             rootHint: "check buffer visibility"
           });
           FINAL(child.finalAnswer);
-        `;
+        `);
       });
 
       const orchestrator = new RlmOrchestrator({
@@ -247,16 +266,16 @@ describe("RlmOrchestrator", () => {
     it("should expose child stats as part of the structured result", async () => {
       const mockLlm = jest.fn(async (_instruction: string, history: string) => {
         if (history.includes("Task:\nchild stats task")) {
-          return "FINAL(context)";
+          return repl("FINAL(context)");
         }
 
-        return `
+        return repl(`
           const child = await sub_rlm({
             prompt: "child stats task",
             context: "child answer"
           });
           FINAL(String(child.stats.rootIterations) + ":" + child.finalAnswer);
-        `;
+        `);
       });
 
       const orchestrator = new RlmOrchestrator({
@@ -273,26 +292,26 @@ describe("RlmOrchestrator", () => {
     it("should aggregate nested child sub_rlm calls into root stats", async () => {
       const mockLlm = jest.fn(async (_instruction: string, history: string) => {
         if (history.includes("Task:\ngrandchild task")) {
-          return "FINAL('deep answer')";
+          return repl("FINAL('deep answer')");
         }
 
         if (history.includes("Task:\nchild task")) {
-          return `
+          return repl(`
             const nested = await sub_rlm({
               prompt: "grandchild task",
               context: "grandchild context"
             });
             FINAL(nested.finalAnswer);
-          `;
+          `);
         }
 
-        return `
+        return repl(`
           const child = await sub_rlm({
             prompt: "child task",
             context: "child context"
           });
           FINAL(child.finalAnswer);
-        `;
+        `);
       });
 
       const orchestrator = new RlmOrchestrator({
@@ -309,26 +328,26 @@ describe("RlmOrchestrator", () => {
     it("should share the root iteration budget across nested child runs", async () => {
       const mockLlm = jest.fn(async (_instruction: string, history: string) => {
         if (history.includes("Task:\nchild task")) {
-          return `
+          return repl(`
             const grandchild = await sub_rlm({
               prompt: "grandchild task",
               context: "grandchild context"
             });
             FINAL(String(grandchild.stats.rootIterations) + ":" + grandchild.finalAnswer);
-          `;
+          `);
         }
 
         if (history.includes("Task:\ngrandchild task")) {
-          return "FINAL('grandchild final')";
+          return repl("FINAL('grandchild final')");
         }
 
-        return `
+        return repl(`
           const child = await sub_rlm({
             prompt: "child task",
             context: "child context"
           });
           FINAL(String(child.stats.rootIterations) + ":" + child.finalAnswer);
-        `;
+        `);
       });
 
       const orchestrator = new RlmOrchestrator({
@@ -347,7 +366,7 @@ describe("RlmOrchestrator", () => {
     it("should enforce a maximum recursion depth for child runs", async () => {
       const mockLlm = jest.fn(async (_instruction: string, history: string) => {
         if (history.includes("Task:\nchild task")) {
-          return `
+          return repl(`
             try {
               await sub_rlm({
                 prompt: "grandchild task",
@@ -357,16 +376,16 @@ describe("RlmOrchestrator", () => {
             } catch (error) {
               FINAL(String(error.code));
             }
-          `;
+          `);
         }
 
-        return `
+        return repl(`
           const child = await sub_rlm({
             prompt: "child task",
             context: "child context"
           });
           FINAL(child.finalAnswer);
-        `;
+        `);
       });
 
       const orchestrator = new RlmOrchestrator({
@@ -386,7 +405,7 @@ describe("RlmOrchestrator", () => {
   describe("completion and recovery", () => {
     it("should support FINAL() with multiline content", async () => {
       const mockLlm = jest.fn(
-        async () => "FINAL('Line 1\\nLine 2\\nLine 3')",
+        async () => repl("FINAL('Line 1\\nLine 2\\nLine 3')"),
       );
       const orchestrator = new RlmOrchestrator({
         ...config,
@@ -402,7 +421,7 @@ describe("RlmOrchestrator", () => {
       let callCount = 0;
       const mockLlm = jest.fn(async () => {
         callCount += 1;
-        return "print('still running')";
+        return repl("print('still running')");
       });
 
       const orchestrator = new RlmOrchestrator({
@@ -440,6 +459,8 @@ describe("RlmOrchestrator", () => {
       expect(result.metadataHistory[0].environment.error?.code).toBe(
         "ROOT_MODEL_QUERY_FAILED",
       );
+      expect(result.stats.totalInputChars).toBeGreaterThan(0);
+      expect(result.stats.totalOutputChars).toBe(0);
     });
 
     it("should continue after script errors and allow later recovery", async () => {
@@ -447,9 +468,9 @@ describe("RlmOrchestrator", () => {
       const mockLlm = jest.fn(async () => {
         callCount += 1;
         if (callCount === 1) {
-          return "throw new Error('script error')";
+          return repl("throw new Error('script error')");
         }
-        return "FINAL('recovered')";
+        return repl("FINAL('recovered')");
       });
 
       const orchestrator = new RlmOrchestrator({
@@ -463,6 +484,29 @@ describe("RlmOrchestrator", () => {
       expect(result.metadataHistory[0].environment.error?.kind).toBe("runtime");
       expect(result.metadataHistory[0].environment.error?.code).toBe(
         "SCRIPT_EXECUTION_FAILED",
+      );
+    });
+
+    it("should reject unfenced root responses instead of executing raw text", async () => {
+      const mockLlm = jest
+        .fn()
+        .mockResolvedValueOnce("FINAL('raw answer')")
+        .mockResolvedValueOnce(repl("FINAL('recovered')"));
+
+      const orchestrator = new RlmOrchestrator({
+        ...config,
+        llmQuery: mockLlm,
+      });
+
+      const result = await orchestrator.runDetailed("test query");
+
+      expect(result.answer).toBe("recovered");
+      expect(result.metadataHistory[0].environment.error?.kind).toBe("llm");
+      expect(result.metadataHistory[0].environment.error?.code).toBe(
+        "ROOT_MODEL_RESPONSE_FORMAT_INVALID",
+      );
+      expect(result.metadataHistory[0].errorFeedback).toContain(
+        "Extra text outside the fence is ignored",
       );
     });
   });

--- a/tests/rlm-prompts.test.ts
+++ b/tests/rlm-prompts.test.ts
@@ -37,6 +37,8 @@ describe("RLM prompts", () => {
       expect(prompt).toContain("FINAL(answer)");
       expect(prompt).toContain("FINAL_VAR(name)");
       expect(prompt).toContain("Fallback summarization is recovery-only");
+      expect(prompt).toContain("Include a fenced ```repl code block");
+      expect(prompt).toContain("will be ignored");
       expect(prompt).not.toContain("research_repository");
     });
   });


### PR DESCRIPTION
## Summary
- harden root-level RLM response parsing and fallback handling
- improve logging coverage around malformed or incomplete model output
- extend orchestrator, prompt, sandbox, and logger tests for the new behavior

## Validation
- attempted targeted Bun test selection, but the requested file path did not exist
- merging as requested without additional cleanup