### PR TITLE
Migrate Codex provider to Codex SDK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ technologies:
       branch: "main" # Optional, defaults to main/master
       description: "JavaScript library for building user interfaces"
 aiProvider: # or llm_provider for backward compatibility
-  type: openai # Options: openai, anthropic, google, openai-compatible, anthropic-compatible, claude-code, gemini-cli, codex-cli
+  type: openai # Options: openai, anthropic, google, openai-compatible, anthropic-compatible, claude-code, gemini-cli, codex-sdk
   apiKey: # API key (loaded from .env as LIBRARIAN_API_KEY if not provided)
   model: gpt-5.2 # Required for openai-compatible and anthropic-compatible providers
   baseURL: # Required for openai-compatible and anthropic-compatible providers
@@ -170,7 +170,7 @@ aiProvider: # or llm_provider for backward compatibility
 - Anthropic-compatible providers (via `@ai-sdk/anthropic` with a required compatible `baseURL`)
 - Claude CLI (requires `claude` command in PATH)
 - Gemini CLI (requires `gemini` command in PATH)
-- Codex CLI (requires `codex` command in PATH)
+- Codex SDK (via `@openai/codex-sdk`, using the same auth as the system `codex` CLI)
 
 ## Testing Strategy
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Librarian CLI allows AI coding agents to:
 - **Repository Management**: Auto-clone and sync from Git before each query
 - **Direct RLM Orchestrator**: API-backed providers run through a metadata-first recursive controller with persistent REPL state
 - **AI SDK Provider Adapters**: Support for OpenAI, Anthropic, Google, and OpenAI-compatible APIs through AI SDK adapters
-- **CLI Provider Routing**: Claude CLI, Gemini CLI, and Codex CLI stay on their native subprocess path
+- **Provider Routing**: Claude CLI and Gemini CLI stay on their native subprocess path; Codex uses the Codex SDK
 - **Dynamic Prompt Construction**: Context-aware system prompts based on technology/group selection
 - **Sandboxed Tool Execution**: Secure file operations within isolated working directories
 - **Integrated Toolset**: Built-in tools for file listing, reading, grep, and glob search
@@ -246,7 +246,7 @@ technologies:
 			description: "LangGraph is low-level orchestration framework..."
 # Optional: Uncomment and configure LLM provider if you want to override OpenCode Zen
 # aiProvider:
-#   type: openai # Options: openai, anthropic, google, openai-compatible, anthropic-compatible, claude-code, gemini-cli, codex-cli
+#   type: openai # Options: openai, anthropic, google, openai-compatible, anthropic-compatible, claude-code, gemini-cli, codex-sdk
 #   apiKey: # API key (loaded from .env as LIBRARIAN_API_KEY if not provided)
 #   model: gpt-5.2 # Required for openai-compatible and anthropic-compatible providers
 #   baseURL: # Required for openai-compatible and anthropic-compatible providers
@@ -367,7 +367,7 @@ technologies:
       description: "LangGraph is low-level orchestration framework..."
 # Optional: Uncomment and configure LLM provider if you want to override OpenCode Zen
 # aiProvider:
-#   type: openai # Options: openai, anthropic, google, openai-compatible, anthropic-compatible, claude-code, gemini-cli, codex-cli
+#   type: openai # Options: openai, anthropic, google, openai-compatible, anthropic-compatible, claude-code, gemini-cli, codex-sdk
 #   apiKey: # API key (loaded from .env as LIBRARIAN_API_KEY if not provided)
 #   model: gpt-5.2 # Required for openai-compatible and anthropic-compatible providers
 #   baseURL: # Required for openai-compatible and anthropic-compatible providers
@@ -412,7 +412,7 @@ Example:
 
 4. **Agent Orchestrator** (`src/agents/`)
    - Direct RLM orchestration for API-backed providers
-   - CLI subprocess routing for Claude CLI, Gemini CLI, and Codex CLI
+   - CLI subprocess routing for Claude CLI and Gemini CLI, plus Codex SDK routing
    - Dynamic system prompt construction based on group/tech context
    - Structured run accounting and logging
 
@@ -481,7 +481,7 @@ This sandbox is suitable for:
 
 ## LLM Provider Configuration
 
-Librarian uses AI SDK adapters for API-backed providers and subprocess routing for CLI-backed providers. It works out-of-the-box with OpenCode Zen (no LLM configuration required by default), and provider switching remains configuration-driven.
+Librarian uses AI SDK adapters for API-backed providers, subprocess routing for Claude/Gemini CLI providers, and the Codex SDK for Codex. It works out-of-the-box with OpenCode Zen (no LLM configuration required by default), and provider switching remains configuration-driven.
 
 By default, the system uses OpenCode Zen:
 
@@ -559,15 +559,15 @@ aiProvider:
 
 **Note**: For Gemini CLI provider, ensure the `gemini` CLI is installed and available in your PATH.
 
-### Codex CLI (CLI-based)
+### Codex SDK
 
 ```yaml
 aiProvider:
-  type: codex-cli
-  model: gpt-5.3-codex # Optional model passed to Codex CLI
+  type: codex-sdk
+  model: gpt-5.4:xhigh # Optional model with optional reasoning effort suffix
 ```
 
-**Note**: For Codex CLI provider, ensure the `codex` CLI is installed and available in your PATH.
+**Note**: Codex SDK uses the same auth as the system `codex` CLI. Librarian does not translate `apiKey` or `LIBRARIAN_API_KEY` into Codex SDK auth, so API keys used for other providers cannot override the local Codex login. Supported reasoning suffixes are `minimal`, `low`, `medium`, `high`, and `xhigh`; a plain model such as `gpt-5.4` is also valid. SDK 0.128.0 does not expose the old `--ephemeral` flag, so Librarian sets `history.persistence = "none"` where supported, while the SDK may still create local session files under the Codex session directory.
 
 **Note**: The same configuration interface works across all providers thanks to the internal adapter layer and OpenCode Zen integration.
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@ai-sdk/google": "^3.0.43",
         "@ai-sdk/openai": "^3.0.41",
         "@ai-sdk/openai-compatible": "^2.0.35",
+        "@openai/codex-sdk": "^0.128.0",
         "ai": "^6.0.116",
         "commander": "^14.0.2",
         "glob": "^13.0.0",
@@ -96,6 +97,22 @@
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
+
+    "@openai/codex": ["@openai/codex@0.128.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.128.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.128.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.128.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.128.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.128.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.128.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-+xp6ODmFfBNnexIWRHApEaPXot2j6gyM8A5we/5IS/uY4eYHj4arETct4hQ5M4eO+MK7JY3ZU4xhuobhlysr0A=="],
+
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.128.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-w+6zohfHx/kHBdles/CyFKaY57u9I3nK8QI9+NrdwMliKA0b7xn13yblRNkMpe09j6vL1oAWoxYsMOQ/vjBGug=="],
+
+    "@openai/codex-darwin-x64": ["@openai/codex@0.128.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-SDbn6fO22Puy8xmMIbZi4f2znMrUEPwABApke4mo+4ihaauwuVjeqzXvW5SPJz5ty/bG11/mSupQgReT7T8BBw=="],
+
+    "@openai/codex-linux-arm64": ["@openai/codex@0.128.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-+SvH73H60qvCXFuQGP/EsmR//s1hHMBR22PvJkXvM/hdnTIGucx+JqRUjAWdmmQ1IU6j3kgwVvdLW/6ICB+M6w=="],
+
+    "@openai/codex-linux-x64": ["@openai/codex@0.128.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-2lnSPA05CRRuKAzFW8BCmmNCSieDcToLwfC2ALLbBYilGLgzhRibjlDglK9F1BkEzfohSSWJu4PBbRu/aG60lQ=="],
+
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.128.0", "", { "dependencies": { "@openai/codex": "0.128.0" } }, "sha512-Eao0LLA5x90qwU6SXYd21h4KxdCef1WpCvHFgKdbqzWMJ79lUvguGDGvx1RheP+zTdKGxJfJ6dulI5wSXoUBhQ=="],
+
+    "@openai/codex-win32-arm64": ["@openai/codex@0.128.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-ECJvsqmYFdA9pn42xxK3Odp/G16AjmBW0BglX8L0PwPjqbstbmlew9bfHf7xvL+SNfNl4NmyotW0+RNo1phgaA=="],
+
+    "@openai/codex-win32-x64": ["@openai/codex@0.128.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-k3jmUAFrzkUtvjGTXvSKjQqJLLlzjxp/VoHJDYedgmXUn6j70HxK38IwapzmnYfiBiTuzETvGwjXHzZgzKjhoQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -145,6 +145,38 @@
     url = "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz";
     hash = "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==";
   };
+  "@openai/codex-sdk@0.128.0" = fetchurl {
+    url = "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.128.0.tgz";
+    hash = "sha512-Eao0LLA5x90qwU6SXYd21h4KxdCef1WpCvHFgKdbqzWMJ79lUvguGDGvx1RheP+zTdKGxJfJ6dulI5wSXoUBhQ==";
+  };
+  "@openai/codex@0.128.0" = fetchurl {
+    url = "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0.tgz";
+    hash = "sha512-+xp6ODmFfBNnexIWRHApEaPXot2j6gyM8A5we/5IS/uY4eYHj4arETct4hQ5M4eO+MK7JY3ZU4xhuobhlysr0A==";
+  };
+  "@openai/codex@0.128.0-darwin-arm64" = fetchurl {
+    url = "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0-darwin-arm64.tgz";
+    hash = "sha512-w+6zohfHx/kHBdles/CyFKaY57u9I3nK8QI9+NrdwMliKA0b7xn13yblRNkMpe09j6vL1oAWoxYsMOQ/vjBGug==";
+  };
+  "@openai/codex@0.128.0-darwin-x64" = fetchurl {
+    url = "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0-darwin-x64.tgz";
+    hash = "sha512-SDbn6fO22Puy8xmMIbZi4f2znMrUEPwABApke4mo+4ihaauwuVjeqzXvW5SPJz5ty/bG11/mSupQgReT7T8BBw==";
+  };
+  "@openai/codex@0.128.0-linux-arm64" = fetchurl {
+    url = "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0-linux-arm64.tgz";
+    hash = "sha512-+SvH73H60qvCXFuQGP/EsmR//s1hHMBR22PvJkXvM/hdnTIGucx+JqRUjAWdmmQ1IU6j3kgwVvdLW/6ICB+M6w==";
+  };
+  "@openai/codex@0.128.0-linux-x64" = fetchurl {
+    url = "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0-linux-x64.tgz";
+    hash = "sha512-2lnSPA05CRRuKAzFW8BCmmNCSieDcToLwfC2ALLbBYilGLgzhRibjlDglK9F1BkEzfohSSWJu4PBbRu/aG60lQ==";
+  };
+  "@openai/codex@0.128.0-win32-arm64" = fetchurl {
+    url = "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0-win32-arm64.tgz";
+    hash = "sha512-ECJvsqmYFdA9pn42xxK3Odp/G16AjmBW0BglX8L0PwPjqbstbmlew9bfHf7xvL+SNfNl4NmyotW0+RNo1phgaA==";
+  };
+  "@openai/codex@0.128.0-win32-x64" = fetchurl {
+    url = "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0-win32-x64.tgz";
+    hash = "sha512-k3jmUAFrzkUtvjGTXvSKjQqJLLlzjxp/VoHJDYedgmXUn6j70HxK38IwapzmnYfiBiTuzETvGwjXHzZgzKjhoQ==";
+  };
   "@opentelemetry/api@1.9.0" = fetchurl {
     url = "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz";
     hash = "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==";

--- a/docs/TechSpec.md
+++ b/docs/TechSpec.md
@@ -515,7 +515,7 @@ src/
 │   │   ├── create-sub-model-query.ts
 │   │   ├── claude-cli.adapter.ts
 │   │   ├── gemini-cli.adapter.ts
-│   │   └── codex-cli.adapter.ts
+│   │   └── codex-sdk.adapter.ts
 │   ├── sandbox/
 │   │   ├── persistent-worker-session.ts
 │   │   ├── environment-metadata.ts

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@ai-sdk/google": "^3.0.43",
     "@ai-sdk/openai": "^3.0.41",
     "@ai-sdk/openai-compatible": "^2.0.35",
+    "@openai/codex-sdk": "^0.128.0",
     "ai": "^6.0.116",
     "commander": "^14.0.2",
     "glob": "^13.0.0",

--- a/src/agents/codex-sdk-adapter.ts
+++ b/src/agents/codex-sdk-adapter.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -18,6 +19,19 @@ const CODEX_REASONING_EFFORTS: readonly ModelReasoningEffort[] = [
   "high",
   "xhigh",
 ];
+
+const CODEX_NPM_NAME = "@openai/codex";
+
+const CODEX_PLATFORM_PACKAGE_BY_TARGET: Record<string, string> = {
+  "x86_64-unknown-linux-musl": "@openai/codex-linux-x64",
+  "aarch64-unknown-linux-musl": "@openai/codex-linux-arm64",
+  "x86_64-apple-darwin": "@openai/codex-darwin-x64",
+  "aarch64-apple-darwin": "@openai/codex-darwin-arm64",
+  "x86_64-pc-windows-msvc": "@openai/codex-win32-x64",
+  "aarch64-pc-windows-msvc": "@openai/codex-win32-arm64",
+};
+
+const moduleRequire = createRequire(import.meta.url);
 
 interface CodexThread {
   runStreamed(input: string): Promise<{
@@ -166,9 +180,77 @@ function resolveCodexPathOverride(): string | undefined {
     return explicitPath;
   }
 
-  // Standalone Bun/Nix builds cannot rely on the SDK's optional-package
-  // resolver, so prefer the same system codex executable the user already runs.
+  const bundledPath = findBundledCodexPath();
+  if (bundledPath) {
+    return bundledPath;
+  }
+
+  // Standalone Bun/Nix builds can hide the SDK's optional platform package from
+  // require.resolve(), so fall back to the user's system codex executable there.
   return findExecutableOnPath("codex");
+}
+
+function findBundledCodexPath(): string | undefined {
+  const targetTriple = codexTargetTriple();
+  const platformPackage = CODEX_PLATFORM_PACKAGE_BY_TARGET[targetTriple];
+  if (!platformPackage) {
+    return undefined;
+  }
+
+  try {
+    const codexPackageJsonPath = moduleRequire.resolve(
+      `${CODEX_NPM_NAME}/package.json`
+    );
+    const codexRequire = createRequire(codexPackageJsonPath);
+    const platformPackageJsonPath = codexRequire.resolve(
+      `${platformPackage}/package.json`
+    );
+    const binaryName = process.platform === "win32" ? "codex.exe" : "codex";
+    return path.join(
+      path.dirname(platformPackageJsonPath),
+      "vendor",
+      targetTriple,
+      "codex",
+      binaryName
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function codexTargetTriple(): string {
+  switch (process.platform) {
+    case "linux":
+    case "android":
+      switch (process.arch) {
+        case "x64":
+          return "x86_64-unknown-linux-musl";
+        case "arm64":
+          return "aarch64-unknown-linux-musl";
+        default:
+          return "";
+      }
+    case "darwin":
+      switch (process.arch) {
+        case "x64":
+          return "x86_64-apple-darwin";
+        case "arm64":
+          return "aarch64-apple-darwin";
+        default:
+          return "";
+      }
+    case "win32":
+      switch (process.arch) {
+        case "x64":
+          return "x86_64-pc-windows-msvc";
+        case "arm64":
+          return "aarch64-pc-windows-msvc";
+        default:
+          return "";
+      }
+    default:
+      return "";
+  }
 }
 
 function findExecutableOnPath(command: string): string | undefined {

--- a/src/agents/codex-sdk-adapter.ts
+++ b/src/agents/codex-sdk-adapter.ts
@@ -1,0 +1,332 @@
+import { copyFile, mkdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  Codex,
+  type CodexOptions,
+  type ModelReasoningEffort,
+  type ThreadEvent,
+  type ThreadOptions,
+} from "@openai/codex-sdk";
+import type { AgentContext } from "./context-schema.js";
+
+const CODEX_REASONING_EFFORTS: readonly ModelReasoningEffort[] = [
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+];
+
+interface CodexThread {
+  runStreamed(input: string): Promise<{
+    events: AsyncGenerator<ThreadEvent>;
+  }>;
+}
+
+interface CodexClient {
+  startThread(options?: ThreadOptions): CodexThread;
+}
+
+interface CodexProviderConfig {
+  apiKey: string;
+  model?: string;
+  baseURL?: string;
+}
+
+export interface CodexModelSelection {
+  model?: string;
+  modelReasoningEffort?: ModelReasoningEffort;
+}
+
+export interface CodexSdkTextStreamState {
+  agentMessageTextById: Map<string, string>;
+  hasEmittedText: boolean;
+}
+
+export interface CodexSdkRuntimeOptions {
+  workingDir: string;
+  query: string;
+  systemPrompt: string;
+  aiProvider: CodexProviderConfig;
+  context?: AgentContext;
+  clientFactory?: (options: CodexOptions) => CodexClient;
+  runtimeFilesFactory?: (systemPrompt: string) => Promise<{
+    tempDir: string;
+    instructionsPath: string;
+    codexHome: string;
+  }>;
+  cleanupRuntimeFiles?: (tempDir: string) => Promise<void>;
+}
+
+function isCodexReasoningEffort(value: string): value is ModelReasoningEffort {
+  switch (value) {
+    case "minimal":
+    case "low":
+    case "medium":
+    case "high":
+    case "xhigh":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function createCodexSdkTextStreamState(): CodexSdkTextStreamState {
+  return { agentMessageTextById: new Map(), hasEmittedText: false };
+}
+
+export function parseCodexModelSelection(
+  modelString: string | undefined
+): CodexModelSelection {
+  const trimmed = modelString?.trim();
+  if (!trimmed) {
+    return {};
+  }
+
+  const parts = trimmed.split(":");
+  if (parts.length > 2) {
+    throw new Error(
+      `Invalid Codex model string "${modelString}". Expected "model" or "model:reasoning_effort".`
+    );
+  }
+
+  const model = parts[0]?.trim();
+  if (!model) {
+    throw new Error(
+      `Invalid Codex model string "${modelString}". Model name is required before the reasoning effort suffix.`
+    );
+  }
+
+  const effort = parts[1]?.trim();
+  if (parts.length === 1) {
+    return { model };
+  }
+
+  if (!(effort && isCodexReasoningEffort(effort))) {
+    throw new Error(
+      `Invalid Codex reasoning effort "${parts[1] ?? ""}". Expected one of: ${CODEX_REASONING_EFFORTS.join(", ")}.`
+    );
+  }
+
+  return { model, modelReasoningEffort: effort };
+}
+
+export function buildCodexSdkClientOptions(
+  aiProvider: CodexProviderConfig,
+  instructionsPath: string,
+  codexHome: string
+): CodexOptions {
+  const baseUrl = aiProvider.baseURL?.trim();
+
+  return {
+    ...(baseUrl ? { baseUrl } : {}),
+    env: buildCodexSdkEnv(codexHome),
+    config: {
+      model_instructions_file: instructionsPath,
+      personality: "friendly",
+      model_reasoning_summary: "none",
+      model_verbosity: "high",
+      notify: [],
+      allow_login_shell: false,
+      file_opener: "none",
+      hide_agent_reasoning: true,
+      show_raw_agent_reasoning: false,
+      check_for_update_on_startup: false,
+      sandbox_workspace_write: {
+        network_access: false,
+      },
+      tools: {
+        web_search: false,
+      },
+      mcp_servers: {},
+      apps: {
+        _default: {
+          enabled: false,
+          open_world_enabled: false,
+        },
+      },
+      history: {
+        persistence: "none",
+      },
+      tui: {
+        notifications: false,
+      },
+    },
+  };
+}
+
+export function buildCodexThreadOptions(
+  aiProvider: CodexProviderConfig,
+  workingDirectory: string
+): ThreadOptions {
+  const modelSelection = parseCodexModelSelection(aiProvider.model);
+
+  return {
+    workingDirectory,
+    skipGitRepoCheck: true,
+    sandboxMode: "read-only",
+    approvalPolicy: "untrusted",
+    networkAccessEnabled: false,
+    webSearchMode: "disabled",
+    webSearchEnabled: false,
+    ...modelSelection,
+  };
+}
+
+function agentMessageDelta(
+  id: string,
+  text: string,
+  state: CodexSdkTextStreamState
+): string | null {
+  const hasSeenMessage = state.agentMessageTextById.has(id);
+  const previousText = state.agentMessageTextById.get(id) ?? "";
+  state.agentMessageTextById.set(id, text);
+
+  if (!text || text === previousText) {
+    return null;
+  }
+
+  if (previousText && text.startsWith(previousText)) {
+    const delta = text.slice(previousText.length);
+    state.hasEmittedText = true;
+    return delta;
+  }
+
+  const separator = state.hasEmittedText && !hasSeenMessage ? "\n" : "";
+  state.hasEmittedText = true;
+  return `${separator}${text}`;
+}
+
+export function codexSdkEventText(
+  event: ThreadEvent,
+  state: CodexSdkTextStreamState = createCodexSdkTextStreamState()
+): string | null {
+  if (
+    (event.type === "item.started" ||
+      event.type === "item.updated" ||
+      event.type === "item.completed") &&
+    event.item.type === "agent_message" &&
+    event.item.text
+  ) {
+    return agentMessageDelta(event.item.id, event.item.text, state);
+  }
+
+  if (event.type === "turn.failed") {
+    throw new Error(`Codex SDK turn failed: ${event.error.message}`);
+  }
+
+  if (event.type === "error") {
+    throw new Error(`Codex SDK stream failed: ${event.message}`);
+  }
+
+  return null;
+}
+
+function envValue(key: string): string | undefined {
+  const value = Bun.env[key];
+  return value ? value : undefined;
+}
+
+export function buildCodexSdkEnv(codexHome: string): Record<string, string> {
+  const env: Record<string, string> = {
+    CODEX_HOME: codexHome,
+    NO_COLOR: "1",
+  };
+
+  for (const key of [
+    "PATH",
+    "HOME",
+    "SHELL",
+    "USER",
+    "LOGNAME",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "LANG",
+    "LC_ALL",
+    "TERM",
+    "SSL_CERT_FILE",
+    "NIX_SSL_CERT_FILE",
+    "GIT_SSL_CAINFO",
+  ]) {
+    const value = envValue(key);
+    if (value) {
+      env[key] = value;
+    }
+  }
+
+  return env;
+}
+
+async function copyCodexAuth(codexHome: string): Promise<void> {
+  const sourceCodexHome =
+    envValue("CODEX_HOME") ?? path.join(os.homedir(), ".codex");
+  const sourceAuthPath = path.join(sourceCodexHome, "auth.json");
+  const targetAuthPath = path.join(codexHome, "auth.json");
+
+  if (!(await Bun.file(sourceAuthPath).exists())) {
+    throw new Error(
+      `Codex auth file not found at ${sourceAuthPath}. Run "codex" locally to authenticate before using the codex-sdk provider.`
+    );
+  }
+
+  await copyFile(sourceAuthPath, targetAuthPath);
+}
+
+export async function createCodexRuntimeFiles(
+  systemPrompt: string
+): Promise<{ tempDir: string; instructionsPath: string; codexHome: string }> {
+  const tempDir = path.join(os.tmpdir(), `librarian-codex-sdk-${Date.now()}`);
+  const instructionsPath = path.join(tempDir, "instructions.md");
+  const codexHome = path.join(tempDir, ".codex-home");
+
+  await mkdir(codexHome, { recursive: true });
+  await Bun.write(instructionsPath, systemPrompt);
+  await copyCodexAuth(codexHome);
+
+  return { tempDir, instructionsPath, codexHome };
+}
+
+export async function cleanupCodexRuntimeFiles(tempDir: string): Promise<void> {
+  await rm(tempDir, { recursive: true, force: true });
+}
+
+export async function* streamCodexSdk(
+  options: CodexSdkRuntimeOptions
+): AsyncGenerator<string, void, unknown> {
+  const workingDir = options.context?.workingDir || options.workingDir;
+  const runtimeFilesFactory =
+    options.runtimeFilesFactory ?? createCodexRuntimeFiles;
+  const cleanupRuntimeFiles =
+    options.cleanupRuntimeFiles ?? cleanupCodexRuntimeFiles;
+  const { tempDir, instructionsPath, codexHome } = await runtimeFilesFactory(
+    options.systemPrompt
+  );
+
+  try {
+    const clientOptions = buildCodexSdkClientOptions(
+      options.aiProvider,
+      instructionsPath,
+      codexHome
+    );
+    const threadOptions = buildCodexThreadOptions(
+      options.aiProvider,
+      workingDir
+    );
+    const client = options.clientFactory
+      ? options.clientFactory(clientOptions)
+      : new Codex(clientOptions);
+    const thread = client.startThread(threadOptions);
+    const { events } = await thread.runStreamed(options.query);
+    const textState = createCodexSdkTextStreamState();
+    for await (const event of events) {
+      const text = codexSdkEventText(event, textState);
+      if (text) {
+        yield text;
+      }
+    }
+  } finally {
+    await cleanupRuntimeFiles(tempDir);
+  }
+}

--- a/src/agents/codex-sdk-adapter.ts
+++ b/src/agents/codex-sdk-adapter.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, rm } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -277,13 +277,20 @@ async function copyCodexAuth(codexHome: string): Promise<void> {
 export async function createCodexRuntimeFiles(
   systemPrompt: string
 ): Promise<{ tempDir: string; instructionsPath: string; codexHome: string }> {
-  const tempDir = path.join(os.tmpdir(), `librarian-codex-sdk-${Date.now()}`);
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "librarian-codex-sdk-"));
   const instructionsPath = path.join(tempDir, "instructions.md");
   const codexHome = path.join(tempDir, ".codex-home");
 
-  await mkdir(codexHome, { recursive: true });
-  await Bun.write(instructionsPath, systemPrompt);
-  await copyCodexAuth(codexHome);
+  try {
+    await mkdir(codexHome, { recursive: true });
+    await Bun.write(instructionsPath, systemPrompt);
+    await copyCodexAuth(codexHome);
+  } catch (error) {
+    // Cleanup must happen here because streamCodexSdk's finally block is not
+    // installed until this setup function resolves.
+    await cleanupCodexRuntimeFiles(tempDir);
+    throw error;
+  }
 
   return { tempDir, instructionsPath, codexHome };
 }

--- a/src/agents/codex-sdk-adapter.ts
+++ b/src/agents/codex-sdk-adapter.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -118,9 +119,11 @@ export function buildCodexSdkClientOptions(
   codexHome: string
 ): CodexOptions {
   const baseUrl = aiProvider.baseURL?.trim();
+  const codexPathOverride = resolveCodexPathOverride();
 
   return {
     ...(baseUrl ? { baseUrl } : {}),
+    ...(codexPathOverride ? { codexPathOverride } : {}),
     env: buildCodexSdkEnv(codexHome),
     config: {
       model_instructions_file: instructionsPath,
@@ -154,6 +157,42 @@ export function buildCodexSdkClientOptions(
       },
     },
   };
+}
+
+function resolveCodexPathOverride(): string | undefined {
+  const explicitPath =
+    envValue("LIBRARIAN_CODEX_PATH") ?? envValue("CODEX_PATH");
+  if (explicitPath) {
+    return explicitPath;
+  }
+
+  // Standalone Bun/Nix builds cannot rely on the SDK's optional-package
+  // resolver, so prefer the same system codex executable the user already runs.
+  return findExecutableOnPath("codex");
+}
+
+function findExecutableOnPath(command: string): string | undefined {
+  const pathEnv = envValue("PATH");
+  if (!pathEnv) {
+    return undefined;
+  }
+
+  const names =
+    process.platform === "win32" ? [`${command}.exe`, command] : [command];
+  for (const directory of pathEnv.split(path.delimiter)) {
+    if (!directory) {
+      continue;
+    }
+
+    for (const name of names) {
+      const candidate = path.join(directory, name);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 export function buildCodexThreadOptions(

--- a/src/agents/react-agent.ts
+++ b/src/agents/react-agent.ts
@@ -57,17 +57,18 @@ export class ReactAgent {
   constructor(config: ReactAgentConfig) {
     this.config = config;
     this.contextSchema = config.contextSchema;
+    let mode: "codex-sdk" | "cli" | "rlm" = "rlm";
+    if (this.config.aiProvider.type === "codex-sdk") {
+      mode = "codex-sdk";
+    } else if (this.isCliProvider()) {
+      mode = "cli";
+    }
 
     logger.info("AGENT", "Initializing ReactAgent", {
       aiProviderType: config.aiProvider.type,
       model: config.aiProvider.model,
       workingDir: config.workingDir.replace(os.homedir(), "~"),
-      mode:
-        this.config.aiProvider.type === "codex-sdk"
-          ? "codex-sdk"
-          : this.isCliProvider()
-            ? "cli"
-            : "rlm",
+      mode,
       hasContextSchema: !!this.contextSchema,
     });
   }

--- a/src/agents/react-agent.ts
+++ b/src/agents/react-agent.ts
@@ -4,11 +4,12 @@ import path from "node:path";
 import type { z } from "zod";
 import { listTool } from "../tools/file-listing.tool.js";
 import { logger } from "../utils/logger.js";
+import { streamCodexSdk } from "./codex-sdk-adapter.js";
 import type { AgentContext } from "./context-schema.js";
 import {
-	RlmOrchestrator,
-	type RlmOrchestratorConfig,
-	type RlmRunResult,
+  RlmOrchestrator,
+  type RlmOrchestratorConfig,
+  type RlmRunResult,
 } from "./rlm-orchestrator.js";
 import { createRlmSystemPrompt } from "./rlm-prompts.js";
 import type { LlmConfig } from "./rlm-sandbox.js";
@@ -21,133 +22,138 @@ export type { AgentContext } from "./context-schema.js";
  * Configuration interface for ReactAgent
  */
 export interface ReactAgentConfig {
-	/** AI provider configuration including type, API key, and optional model/base URL */
-	aiProvider: {
-		type:
-			| "openai"
-			| "anthropic"
-			| "google"
-			| "openai-compatible"
-			| "anthropic-compatible"
-			| "claude-code"
-			| "gemini-cli"
-			| "codex-cli";
-		apiKey: string;
-		model?: string;
-		baseURL?: string;
-	};
-	/** Working directory where the agent operates */
-	workingDir: string;
-	/** Optional technology context for dynamic system prompt construction */
-	technology?: {
-		name: string;
-		repository: string;
-		branch: string;
-	};
-	/** Optional context schema for runtime context validation */
-	contextSchema?: z.ZodType | undefined;
+  /** AI provider configuration including type, API key, and optional model/base URL */
+  aiProvider: {
+    type:
+      | "openai"
+      | "anthropic"
+      | "google"
+      | "openai-compatible"
+      | "anthropic-compatible"
+      | "claude-code"
+      | "gemini-cli"
+      | "codex-sdk";
+    apiKey: string;
+    model?: string;
+    baseURL?: string;
+  };
+  /** Working directory where the agent operates */
+  workingDir: string;
+  /** Optional technology context for dynamic system prompt construction */
+  technology?: {
+    name: string;
+    repository: string;
+    branch: string;
+  };
+  /** Optional context schema for runtime context validation */
+  contextSchema?: z.ZodType | undefined;
 }
 
 export class ReactAgent {
-	private rlmOrchestrator?: RlmOrchestrator;
-	private readonly config: ReactAgentConfig;
-	private readonly contextSchema?: z.ZodType | undefined;
+  private rlmOrchestrator?: RlmOrchestrator;
+  private readonly config: ReactAgentConfig;
+  private readonly contextSchema?: z.ZodType | undefined;
 
-	constructor(config: ReactAgentConfig) {
-		this.config = config;
-		this.contextSchema = config.contextSchema;
+  constructor(config: ReactAgentConfig) {
+    this.config = config;
+    this.contextSchema = config.contextSchema;
 
-		logger.info("AGENT", "Initializing ReactAgent", {
-			aiProviderType: config.aiProvider.type,
-			model: config.aiProvider.model,
-			workingDir: config.workingDir.replace(os.homedir(), "~"),
-			mode: this.isCliProvider() ? "cli" : "rlm",
-			hasContextSchema: !!this.contextSchema,
-		});
-	}
+    logger.info("AGENT", "Initializing ReactAgent", {
+      aiProviderType: config.aiProvider.type,
+      model: config.aiProvider.model,
+      workingDir: config.workingDir.replace(os.homedir(), "~"),
+      mode:
+        this.config.aiProvider.type === "codex-sdk"
+          ? "codex-sdk"
+          : this.isCliProvider()
+            ? "cli"
+            : "rlm",
+      hasContextSchema: !!this.contextSchema,
+    });
+  }
 
-	/**
-	 * Generates a pre-computed directory listing for the repository at depth 2.
-	 * This is used to provide the agent with structural context about the codebase.
-	 *
-	 * @param workingDir - The directory to list
-	 * @returns The directory listing as a string, or undefined if it fails
-	 */
-	private async getRepoOutline(
-		workingDir: string,
-	): Promise<string | undefined> {
-		try {
-			const toolContext = { workingDir, group: "", technology: "" };
-			const result = await listTool.invoke(
-				{
-					directoryPath: ".",
-					recursive: true,
-					maxDepth: 2,
-					includeHidden: false,
-				},
-				{ context: toolContext },
-			);
+  /**
+   * Generates a pre-computed directory listing for the repository at depth 2.
+   * This is used to provide the agent with structural context about the codebase.
+   *
+   * @param workingDir - The directory to list
+   * @returns The directory listing as a string, or undefined if it fails
+   */
+  private async getRepoOutline(
+    workingDir: string
+  ): Promise<string | undefined> {
+    try {
+      const toolContext = { workingDir, group: "", technology: "" };
+      const result = await listTool.invoke(
+        {
+          directoryPath: ".",
+          recursive: true,
+          maxDepth: 2,
+          includeHidden: false,
+        },
+        { context: toolContext }
+      );
 
-			// Parse to get a cleaner format for the prompt
-			const parsed = JSON.parse(result);
+      // Parse to get a cleaner format for the prompt
+      const parsed = JSON.parse(result);
 
-			// Format as a simple tree structure for readability
-			const lines: string[] = [];
-			for (const entry of parsed.entries || []) {
-				const indent = entry.depth === 0 ? "" : "  ".repeat(entry.depth);
-				const marker = entry.isDirectory ? "[DIR]" : "[FILE]";
-				const size = entry.size
-					? ` (${entry.lineCount || entry.size} ${entry.isDirectory ? "items" : "lines"})`
-					: "";
-				lines.push(`${indent}${marker} ${entry.name}${size}`);
-			}
+      // Format as a simple tree structure for readability
+      const lines: string[] = [];
+      for (const entry of parsed.entries || []) {
+        const indent = entry.depth === 0 ? "" : "  ".repeat(entry.depth);
+        const marker = entry.isDirectory ? "[DIR]" : "[FILE]";
+        const size = entry.size
+          ? ` (${entry.lineCount || entry.size} ${entry.isDirectory ? "items" : "lines"})`
+          : "";
+        lines.push(`${indent}${marker} ${entry.name}${size}`);
+      }
 
-			return lines.join("\n");
-		} catch (error) {
-			logger.warn("AGENT", "Failed to generate repo outline", {
-				workingDir: workingDir.replace(os.homedir(), "~"),
-				error: error instanceof Error ? error.message : String(error),
-			});
-			return undefined;
-		}
-	}
+      return lines.join("\n");
+    } catch (error) {
+      logger.warn("AGENT", "Failed to generate repo outline", {
+        workingDir: workingDir.replace(os.homedir(), "~"),
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
 
-	/**
-	 * Builds the context block describing the repository
-	 */
-	private buildContextBlock(): string {
-		const { workingDir, technology } = this.config;
+  /**
+   * Builds the context block describing the repository
+   */
+  private buildContextBlock(): string {
+    const { workingDir, technology } = this.config;
 
-		if (technology) {
-			return `You have been provided the **${technology.name}** repository.
+    if (technology) {
+      return `You have been provided the **${technology.name}** repository.
 Repository: ${technology.repository}
 Your Working Directory: ${workingDir}`;
-		}
-		return `You have been provided several related repositories to work with grouped in the following working directory: ${workingDir}`;
-	}
+    }
+    return `You have been provided several related repositories to work with grouped in the following working directory: ${workingDir}`;
+  }
 
-	/**
-	 * Creates the RLM (Recursive Language Model) system prompt for API-backed providers.
-	 * Delegates to rlm-prompts.ts for the actual prompt template.
-	 *
-	 * @param repoOutline - Optional pre-computed directory listing
-	 * @returns A context-aware RLM system prompt string
-	 */
-	createRlmSystemPrompt(repoOutline?: string): string {
-		const contextBlock = this.buildContextBlock();
-		return createRlmSystemPrompt(contextBlock, repoOutline);
-	}
+  /**
+   * Creates the RLM (Recursive Language Model) system prompt for API-backed providers.
+   * Delegates to rlm-prompts.ts for the actual prompt template.
+   *
+   * @param repoOutline - Optional pre-computed directory listing
+   * @returns A context-aware RLM system prompt string
+   */
+  createRlmSystemPrompt(repoOutline?: string): string {
+    const contextBlock = this.buildContextBlock();
+    return createRlmSystemPrompt(contextBlock, repoOutline);
+  }
 
-	/**
-	 * Creates a dynamic system prompt based on current configuration and technology context.
-	 * Used by CLI providers (claude-code, gemini-cli, codex-cli).
-	 * @returns A context-aware system prompt string
-	 */
-	createDynamicSystemPrompt(): string {
-		const { workingDir, technology } = this.config;
+  /**
+   * Creates a dynamic system prompt based on current configuration and technology context.
+   * Used by CLI/SDK providers (claude-code, gemini-cli, codex-sdk).
+   * @returns A context-aware system prompt string
+   */
+  createDynamicSystemPrompt(): string {
+    const { workingDir, technology } = this.config;
 
-		// Dynamic system prompt generation code
-		let prompt = `
+    // Dynamic system prompt generation code
+    let prompt = `
 You are a **Codebase Investigator**. Your mission is to provide technical insights grounded in source code evidence. You approach every query as a methodical investigation, prioritizing verification over assumptions and ensuring every conclusion is backed by specific file citations.
 
 # Instructions
@@ -290,878 +296,556 @@ Remember: ALL tool calls MUST be executed using absolute path in \`[WORKING_DIRE
 **Final Reminder: Every claim must be backed by evidence. If you haven't verified it in the code, don't say it.**
 `;
 
-		// Add technology context if available
-		if (technology) {
-			prompt = prompt.replace(
-				"<context_block>",
-				`You have been provided the **${technology.name}** repository.
+    // Add technology context if available
+    if (technology) {
+      prompt = prompt.replace(
+        "<context_block>",
+        `You have been provided the **${technology.name}** repository.
 Repository: ${technology.repository}
 Your Working Directory: ${workingDir}
 
-Remember that ALL tool calls MUST be executed using absolute path in \`${workingDir}\``,
-			);
-			prompt = prompt.replace("</context_block>", "");
-		} else {
-			prompt = prompt.replace(
-				"<context_block>",
-				`You have been provided several related repositories to work with grouped in the following working directory: ${workingDir}
-
-Remember that ALL tool calls MUST be executed using absolute path in \`${workingDir}\``,
-			);
-			prompt = prompt.replace("</context_block>", "");
-		}
-
-		logger.debug("AGENT", "Dynamic system prompt generated", {
-			hasTechnologyContext: !!technology,
-			promptLength: prompt.length,
-		});
-
-		return prompt;
-	}
-
-	private async createGeminiTempDir(): Promise<string> {
-		const tempDir = path.join(os.tmpdir(), `librarian-gemini-${Date.now()}`);
-		await mkdir(tempDir, { recursive: true });
-		return tempDir;
-	}
-
-	private async setupGeminiConfig(
-		tempDir: string,
-		systemPrompt: string,
-		_model: string,
-	): Promise<{ systemPromptPath: string; settingsPath: string }> {
-		const systemPromptPath = path.join(tempDir, "system.md");
-		const settingsPath = path.join(tempDir, "settings.json");
-
-		await Bun.write(systemPromptPath, systemPrompt);
-
-		const settings = {
-			tools: {
-				core: ["list_directory", "read_file", "glob", "search_file_content"],
-				autoAccept: true,
-			},
-			mcpServers: {},
-			mcp: {
-				excluded: ["*"],
-			},
-			experimental: {
-				enableAgents: false,
-			},
-			output: {
-				format: "json",
-			},
-		};
-		await Bun.write(settingsPath, JSON.stringify(settings, null, 2));
-
-		return { systemPromptPath, settingsPath };
-	}
-
-	private buildGeminiEnv(
-		tempDir: string,
-		model: string,
-	): Record<string, string | undefined> {
-		const settingsPath = path.join(tempDir, "settings.json");
-		const systemPromptPath = path.join(tempDir, "system.md");
-
-		return {
-			...Bun.env,
-			GEMINI_SYSTEM_MD: systemPromptPath,
-			GEMINI_CLI_SYSTEM_DEFAULTS_PATH: settingsPath,
-			GEMINI_CLI_SYSTEM_SETTINGS_PATH: settingsPath,
-			GEMINI_MODEL: model,
-		};
-	}
-
-	private async cleanupGeminiTempDir(tempDir: string): Promise<void> {
-		try {
-			await rm(tempDir, { recursive: true, force: true });
-		} catch (err) {
-			logger.warn("AGENT", "Failed to cleanup Gemini temp files", {
-				error: err,
-			});
-		}
-	}
-
-	private async createCodexTempDir(): Promise<string> {
-		const tempDir = path.join(os.tmpdir(), `librarian-codex-${Date.now()}`);
-		await mkdir(tempDir, { recursive: true });
-		return tempDir;
-	}
-
-	private async setupCodexConfig(
-		tempDir: string,
-		systemPrompt: string,
-	): Promise<{ instructionsPath: string; configPath: string; codexHome: string }> {
-		const instructionsPath = path.join(tempDir, "instructions.md");
-		const codexHome = path.join(tempDir, ".codex-home");
-		const configPath = path.join(codexHome, "config.toml");
-
-		// Write the system prompt to a file
-		await Bun.write(instructionsPath, systemPrompt);
-		await mkdir(codexHome, { recursive: true });
-
-		// Create Codex config that uses the instructions file
-		const config = `# Librarian Codex Configuration
-# This config is isolated from user config
-#
-# Notes
-# - Root keys must appear before tables in TOML.
-# - Optional keys that default to "unset" are shown commented out with notes.
-# - MCP servers, profiles, and model providers are examples; remove or edit.
-
-################################################################################
-# Core Model Selection
-################################################################################
-
-# Primary model used by Codex. Default: "gpt-5.2-codex" on all platforms.
-model = "gpt-5.3-codex"
-
-# Default communication style for supported models. Default: "friendly".
-# Allowed values: none | friendly | pragmatic
-personality = "friendly"
-
-################################################################################
-# Reasoning & Verbosity (Responses API capable models)
-################################################################################
-
-# Reasoning effort: minimal | low | medium | high | xhigh (default: medium; xhigh on gpt-5.2-codex and gpt-5.2)
-model_reasoning_effort = "high"
-
-# Reasoning summary: auto | concise | detailed | none (default: auto)
-model_reasoning_summary = "none"
-
-# Text verbosity for GPT-5 family (Responses API): low | medium | high (default: medium)
-model_verbosity = "high"
-
-################################################################################
-# Instruction Overrides
-################################################################################
-
-# Override built-in base instructions with a file path. Default: unset.
-model_instructions_file = "${instructionsPath}"
-
-################################################################################
-# Notifications
-################################################################################
-
-# External notifier program (argv array). When unset: disabled.
-# Example: notify = ["notify-send", "Codex"]
-notify = [ ]
-
-################################################################################
-# Approval & Sandbox
-################################################################################
-
-# When to ask for command approval:
-# - untrusted: only known-safe read-only commands auto-run; others prompt
-# - on-request: model decides when to ask (default)
-# - never: never prompt (risky)
-# - { reject = { ... } }: auto-reject selected prompt categories
-approval_policy = "untrusted"
-# Example granular auto-reject policy:
-# approval_policy = { reject = { sandbox_approval = true, rules = false, mcp_elicitations = false } }
-
-# Allow login-shell semantics for shell-based tools when they request \`login = true\`.
-# Default: true. Set false to force non-login shells and reject explicit login-shell requests.
-allow_login_shell = false
-
-# Filesystem/network sandbox policy for tool calls:
-# - read-only (default)
-# - workspace-write
-# - danger-full-access (no sandbox; extremely risky)
-sandbox_mode = "read-only"
-
-################################################################################
-# History & File Opener
-################################################################################
-
-# URI scheme for clickable citations: vscode (default) | vscode-insiders | windsurf | cursor | none
-file_opener = "none"
-
-################################################################################
-# UI, Notifications, and Misc
-################################################################################
-
-# Suppress internal reasoning events from output. Default: false
-hide_agent_reasoning = true
-
-# Show raw reasoning content when available. Default: false
-show_raw_agent_reasoning = true
-
-# Check for updates on startup. Default: true
-check_for_update_on_startup = false
-
-################################################################################
-# Sandbox Advanced Settings
-################################################################################
-[sandbox_workspace_write]
-# Allow outbound network access inside the sandbox
-network_access = false
-
-################################################################################
-# Web Search
-################################################################################
-
-# Web search mode: disabled | cached | live. Default: "cached"
-# cached serves results from a web search cache (an OpenAI-maintained index).
-# cached returns pre-indexed results; live fetches the most recent data.
-# If you use --yolo or another full access sandbox setting, web search defaults to live.
-web_search = "disabled"
-
-################################################################################
-# Tool Controls
-################################################################################
-
-[tools]
-# Disable native web search tool regardless of mode defaults.
-web_search = false
-
-################################################################################
-# External Integrations
-################################################################################
-
-[mcp_servers]
-# Keep empty to prevent inherited MCP tool access.
-
-[apps._default]
-# Disable app/connectors so no external app tool can be invoked.
-enabled = false
-open_world_enabled = false
-
-################################################################################
-# History (table)
-################################################################################
-
-[history]
-# save-all (default) | none
-persistence = "none"
-
-################################################################################
-# UI, Notifications, and Misc (tables)
-################################################################################
-
-[tui]
-# Desktop notifications from the TUI: boolean or filtered list. Default: true
-# Examples: false | ["agent-turn-complete", "approval-requested"]
-notifications = false
-
-`;
-
-		await Bun.write(configPath, config);
-		await this.copyCodexAuthFile(codexHome);
-
-		return { instructionsPath, configPath, codexHome };
-	}
-
-	private async copyCodexAuthFile(codexHome: string): Promise<void> {
-		const sourceCodexHome = Bun.env.CODEX_HOME || path.join(os.homedir(), ".codex");
-		const sourceAuthPath = path.join(sourceCodexHome, "auth.json");
-		const targetAuthPath = path.join(codexHome, "auth.json");
-
-		const sourceAuth = Bun.file(sourceAuthPath);
-		if (!(await sourceAuth.exists())) {
-			logger.warn("AGENT", "Codex auth file not found in source CODEX_HOME", {
-				sourceCodexHome: sourceCodexHome.replace(os.homedir(), "~"),
-			});
-			return;
-		}
-
-		await Bun.write(targetAuthPath, sourceAuth);
-	}
-
-	private buildCodexEnv(
-		codexHome: string,
-		model?: string,
-	): Record<string, string | undefined> {
-		const env = { ...Bun.env };
-		delete env.CODEX_HOME;
-		delete env.CODEX_CONFIG_PATH;
-		delete env.CODEX_THREAD_ID;
-
-		return {
-			...env,
-			CODEX_HOME: codexHome,
-			...(model && { CODEX_MODEL: model }),
-		};
-	}
-
-	private async cleanupCodexTempDir(tempDir: string): Promise<void> {
-		try {
-			await rm(tempDir, { recursive: true, force: true });
-		} catch (err) {
-			logger.warn("AGENT", "Failed to cleanup Codex temp files", {
-				error: err,
-			});
-		}
-	}
-
-	private async *streamClaudeCli(
-		query: string,
-		context?: AgentContext,
-	): AsyncGenerator<string, void, unknown> {
-		const workingDir = context?.workingDir || this.config.workingDir;
-		const systemPrompt = this.createDynamicSystemPrompt();
-
-		const args = [
-			"-p",
-			query,
-			"--system-prompt",
-			systemPrompt,
-			"--tools",
-			"Read,Glob,Grep",
-			"--dangerously-skip-permissions",
-			"--output-format",
-			"stream-json",
-		];
-
-		const env = {
-			...Bun.env,
-			CLAUDE_PROJECT_DIR: workingDir,
-			...(this.config.aiProvider.model && {
-				ANTHROPIC_MODEL: this.config.aiProvider.model,
-			}),
-		};
-
-		logger.debug("AGENT", "Spawning Claude CLI", {
-			args: args.map((a) => (a.length > 100 ? `${a.substring(0, 100)}...` : a)),
-			workingDir,
-		});
-
-		const proc = Bun.spawn(["claude", ...args], {
-			cwd: workingDir,
-			env,
-			stdout: "pipe",
-			stderr: "pipe",
-		});
-
-		let buffer = "";
-
-		if (!proc.stdout) {
-			throw new Error("Failed to capture Claude CLI output");
-		}
-
-		const stderrPromise = proc.stderr
-			? new Response(proc.stderr).text()
-			: Promise.resolve("");
-		const decoder = new TextDecoder();
-		const reader = proc.stdout.getReader();
-
-		while (true) {
-			const { done, value } = await reader.read();
-			if (done) {
-				break;
-			}
-
-			buffer += decoder.decode(value, { stream: true });
-			const lines = buffer.split("\n");
-			buffer = lines.pop() || "";
-
-			for (const line of lines) {
-				if (!line.trim()) {
-					continue;
-				}
-				try {
-					const data = JSON.parse(line);
-					// Filter for text content blocks in the stream
-					if (data.type === "text" && data.content) {
-						yield data.content;
-					} else if (data.type === "content_block_delta" && data.delta?.text) {
-						yield data.delta.text;
-					} else if (data.type === "message" && Array.isArray(data.content)) {
-						// Final message might come as a whole
-						for (const block of data.content) {
-							if (block.type === "text" && block.text) {
-								yield block.text;
-							}
-						}
-					}
-				} catch {
-					// Silent fail for non-JSON or partial lines
-				}
-			}
-		}
-
-		buffer += decoder.decode();
-		if (buffer.trim()) {
-			try {
-				const data = JSON.parse(buffer);
-				// Handle trailing partial line if the stream didn't end with newline
-				if (data.type === "text" && data.content) {
-					yield data.content;
-				} else if (data.type === "content_block_delta" && data.delta?.text) {
-					yield data.delta.text;
-				} else if (data.type === "message" && Array.isArray(data.content)) {
-					for (const block of data.content) {
-						if (block.type === "text" && block.text) {
-							yield block.text;
-						}
-					}
-				}
-			} catch {
-				// Ignore non-JSON trailing log lines emitted by claude CLI.
-			}
-		}
-
-		const [exitCode, stderrOutput] = await Promise.all([
-			proc.exited,
-			stderrPromise,
-		]);
-		if (exitCode !== 0) {
-			const stderrPreview = stderrOutput.trim().slice(0, 500);
-			throw new Error(
-				stderrPreview
-					? `Claude CLI exited with code ${exitCode}: ${stderrPreview}`
-					: `Claude CLI exited with code ${exitCode}`,
-			);
-		}
-	}
-
-	private async *streamGeminiCli(
-		query: string,
-		context?: AgentContext,
-	): AsyncGenerator<string, void, unknown> {
-		const workingDir = context?.workingDir || this.config.workingDir;
-		const systemPrompt = this.createDynamicSystemPrompt();
-
-		const tempDir = await this.createGeminiTempDir();
-		const model = this.config.aiProvider.model || "gemini-2.5-flash";
-
-		try {
-			await this.setupGeminiConfig(tempDir, systemPrompt, model);
-
-			const args = [
-				"gemini",
-				"-p",
-				query,
-				"--output-format",
-				"stream-json",
-				"--yolo",
-			];
-
-			const env = this.buildGeminiEnv(tempDir, model);
-
-			logger.debug("AGENT", "Spawning Gemini CLI", {
-				args,
-				workingDir,
-				model,
-			});
-
-			const proc = Bun.spawn(args, {
-				cwd: workingDir,
-				env,
-				stdout: "pipe",
-				stderr: "pipe",
-			});
-
-			const reader = proc.stdout.getReader();
-			let buffer = "";
-
-			while (true) {
-				const { done, value } = await reader.read();
-				if (done) {
-					break;
-				}
-
-				buffer += new TextDecoder().decode(value);
-				const lines = buffer.split("\n");
-				buffer = lines.pop() || "";
-
-				for (const line of lines) {
-					if (!line.trim()) {
-						continue;
-					}
-					try {
-						const data = JSON.parse(line);
-						const text = this.parseGeminiStreamLine(data);
-						if (text) {
-							yield text;
-						}
-					} catch {
-						// Silent fail for non-JSON or partial lines
-					}
-				}
-			}
-
-			const exitCode = await proc.exited;
-			if (exitCode !== 0) {
-				throw new Error(`Gemini CLI exited with code ${exitCode}`);
-			}
-		} finally {
-			await this.cleanupGeminiTempDir(tempDir);
-		}
-	}
-
-	private parseGeminiStreamLine(data: unknown): string | null {
-		if (
-			data &&
-			typeof data === "object" &&
-			"type" in data &&
-			"role" in data &&
-			"content" in data
-		) {
-			const typedData = data as { type: string; role: string; content: string };
-			if (
-				typedData.type === "message" &&
-				typedData.role === "assistant" &&
-				typedData.content
-			) {
-				return typedData.content;
-			}
-		}
-		return null;
-	}
-
-	private parseCodexExecStreamLine(data: unknown): string | null {
-		if (!data || typeof data !== "object" || !("type" in data)) {
-			return null;
-		}
-
-		const typedData = data as {
-			type: string;
-			item?: {
-				type?: string;
-				text?: string;
-			};
-		};
-
-		if (
-			typedData.type === "item.completed" &&
-			typedData.item?.type === "agent_message" &&
-			typedData.item.text
-		) {
-			return typedData.item.text;
-		}
-
-		return null;
-	}
-
-	private async *streamCodexCli(
-		query: string,
-		context?: AgentContext,
-	): AsyncGenerator<string, void, unknown> {
-		const workingDir = context?.workingDir || this.config.workingDir;
-		const systemPrompt = this.createDynamicSystemPrompt();
-
-		// Create a temporary directory with isolated Codex config
-		const tempDir = await this.createCodexTempDir();
-		const model = this.config.aiProvider.model;
-
-		try {
-			const codexSetup = await this.setupCodexConfig(tempDir, systemPrompt);
-
-			// Build args - now simpler since config is in the temp file
-			const args = [
-				"exec",
-				"--json",
-				"--ephemeral",
-				"--sandbox",
-				"read-only",
-				"--skip-git-repo-check",
-				"--color",
-				"never",
-				...(model ? ["-m", model] : []),
-				"--",
-				query,
-			];
-
-			const env = this.buildCodexEnv(codexSetup.codexHome, model);
-
-			logger.debug("AGENT", "Spawning Codex CLI", {
-				workingDir,
-				model: model || "default",
-				queryLength: query.length,
-				systemPromptLength: systemPrompt.length,
-				mode: "read-only",
-				configPath: codexSetup.configPath,
-				codexHome: codexSetup.codexHome,
-			});
-
-			const proc = Bun.spawn(["codex", ...args], {
-				cwd: workingDir,
-				env,
-				stdout: "pipe",
-				stderr: "pipe",
-			});
-
-			if (!proc.stdout) {
-				throw new Error("Failed to capture Codex CLI output");
-			}
-
-			const stderrPromise = proc.stderr
-				? new Response(proc.stderr).text()
-				: Promise.resolve("");
-
-			let buffer = "";
-			const decoder = new TextDecoder();
-			const reader = proc.stdout.getReader();
-
-			while (true) {
-				const { done, value } = await reader.read();
-				if (done) {
-					break;
-				}
-
-				buffer += decoder.decode(value, { stream: true });
-				const lines = buffer.split("\n");
-				buffer = lines.pop() || "";
-
-				for (const line of lines) {
-					if (!line.trim()) {
-						continue;
-					}
-					try {
-						const data = JSON.parse(line);
-						const text = this.parseCodexExecStreamLine(data);
-						if (text) {
-							yield text;
-						}
-					} catch {
-						// Ignore non-JSON log lines emitted by codex CLI.
-					}
-				}
-			}
-
-			buffer += decoder.decode();
-			if (buffer.trim()) {
-				try {
-					const data = JSON.parse(buffer);
-					const text = this.parseCodexExecStreamLine(data);
-					if (text) {
-						yield text;
-					}
-				} catch {
-					// Ignore non-JSON trailing log lines emitted by codex CLI.
-				}
-			}
-
-			const [exitCode, stderrOutput] = await Promise.all([
-				proc.exited,
-				stderrPromise,
-			]);
-			if (exitCode !== 0) {
-				const stderrPreview = stderrOutput.trim().slice(0, 500);
-				throw new Error(
-					stderrPreview
-						? `Codex CLI exited with code ${exitCode}: ${stderrPreview}`
-						: `Codex CLI exited with code ${exitCode}`,
-				);
-			}
-		} finally {
-			await this.cleanupCodexTempDir(tempDir);
-		}
-	}
-
-	private isCliProvider(): boolean {
-		return (
-			this.config.aiProvider.type === "claude-code" ||
-			this.config.aiProvider.type === "gemini-cli" ||
-			this.config.aiProvider.type === "codex-cli"
-		);
-	}
-
-	async initialize(): Promise<void> {
-		if (this.isCliProvider()) {
-			logger.info(
-				"AGENT",
-				`${this.config.aiProvider.type} CLI mode initialized`,
-			);
-			return;
-		}
-
-		logger.info("AGENT", "Direct RLM mode initialized", {
-			hasContextSchema: !!this.contextSchema,
-		});
-	}
-
-	/**
-	 * Query repository with a given query and optional context
-	 *
-	 * @param repoPath - The repository path (deprecated, for compatibility)
-	 * @param query - The query string
-	 * @param context - Optional context object containing working directory and metadata
-	 * @returns The agent's response as a string
-	 */
-	async queryRepository(
-		_repoPath: string,
-		query: string,
-		context?: AgentContext,
-	): Promise<string> {
-		logger.info("AGENT", "Query started", {
-			queryLength: query.length,
-			hasContext: !!context,
-		});
-
-		// Use RLM mode for supported providers (not CLI-based ones)
-		if (this.shouldUseRlm()) {
-			logger.info("AGENT", "Using RLM mode");
-			const result = await this.executeRlmQuery(query);
-			logger.info("AGENT", "RLM query result received", {
-				root_iterations: result.stats.rootIterations,
-				sub_rlm_calls: result.stats.subRlmCalls,
-				sub_model_calls: result.stats.subModelCalls,
-				repo_calls: result.stats.repoCalls,
-				total_input_chars: result.stats.totalInputChars,
-				total_output_chars: result.stats.totalOutputChars,
-				final_set: result.stats.finalSet,
-				fallback_recovery_used: result.stats.fallbackRecoveryUsed,
-				metadata_history_entries: result.metadataHistory.length,
-				last_error:
-					result.metadataHistory[result.metadataHistory.length - 1]?.environment.error
-						?.message ?? null,
-			});
-			return result.answer;
-		}
-
-		if (this.config.aiProvider.type === "claude-code") {
-			let fullContent = "";
-			for await (const chunk of this.streamClaudeCli(query, context)) {
-				fullContent += chunk;
-			}
-			return fullContent;
-		}
-
-		if (this.config.aiProvider.type === "gemini-cli") {
-			let fullContent = "";
-			for await (const chunk of this.streamGeminiCli(query, context)) {
-				fullContent += chunk;
-			}
-			return fullContent;
-		}
-
-		if (this.config.aiProvider.type === "codex-cli") {
-			let fullContent = "";
-			for await (const chunk of this.streamCodexCli(query, context)) {
-				fullContent += chunk;
-			}
-			return fullContent;
-		}
-
-		throw new Error(
-			`Unsupported AI provider for direct repository query: ${this.config.aiProvider.type}`,
-		);
-	}
-
-	/**
-	 * Check if RLM mode should be used based on provider type
-	 * RLM mode is used for API-based providers (OpenAI, Anthropic, Google)
-	 * CLI-based providers (claude-code, gemini-cli, codex-cli) use their own execution path
-	 */
-	private shouldUseRlm(): boolean {
-		const rlmProviders = [
-			"openai",
-			"anthropic",
-			"google",
-			"openai-compatible",
-			"anthropic-compatible",
-		];
-		return rlmProviders.includes(this.config.aiProvider.type);
-	}
-
-	/**
-	 * Initialize the RLM orchestrator on first use
-	 */
-	private initializeRlmOrchestrator(): void {
-		const llmConfig: LlmConfig = {
-			type: this.config.aiProvider.type as LlmConfig["type"],
-			apiKey: this.config.aiProvider.apiKey,
-			model: this.config.aiProvider.model,
-			baseURL: this.config.aiProvider.baseURL,
-		};
-
-		const orchestratorConfig: RlmOrchestratorConfig = {
-			llmConfig,
-			rootMetadataLoader: () => this.loadRootMetadata(),
-			workingDir: this.config.workingDir,
-			maxIterations: 30,
-			stdoutPreviewLength: 2000,
-			systemPrompt: this.createRlmSystemPrompt(),
-		};
-
-		this.rlmOrchestrator = new RlmOrchestrator(orchestratorConfig);
-		logger.info("AGENT", "RLM Orchestrator initialized", {
-			workingDir: this.config.workingDir,
-			maxIterations: orchestratorConfig.maxIterations,
-		});
-	}
-
-	private async loadRootMetadata(): Promise<RootRepoMetadata> {
-		const { workingDir, technology } = this.config;
-		let topLevelEntries: RootRepoMetadata["topLevelEntries"] = [];
-
-		try {
-			const rawListing = await listTool.invoke(
-				{
-					directoryPath: ".",
-					recursive: false,
-					maxDepth: 1,
-					includeHidden: false,
-				},
-				{ context: { workingDir, group: "", technology: "" } },
-			);
-			const listing = JSON.parse(rawListing) as {
-				entries?: Array<{
-					name: string;
-					path: string;
-					isDirectory: boolean;
-					size?: number;
-					lineCount?: number;
-					depth?: number;
-				}>;
-				error?: unknown;
-				message?: unknown;
-			};
-
-			if (!Array.isArray(listing.entries)) {
-				logger.warn("AGENT", "Root metadata listing returned no entries", {
-					workingDir: workingDir.replace(os.homedir(), "~"),
-					...(typeof listing.message === "string"
-						? { message: listing.message }
-						: {}),
-				});
-			} else {
-				topLevelEntries = listing.entries.map((entry) => ({
-					name: entry.name,
-					path: entry.path,
-					isDirectory: entry.isDirectory,
-					...(entry.size !== undefined ? { size: entry.size } : {}),
-					...(entry.lineCount !== undefined ? { lineCount: entry.lineCount } : {}),
-					...(entry.depth !== undefined ? { depth: entry.depth } : {}),
-				}));
-			}
-		} catch (error) {
-			logger.warn("AGENT", "Failed to load root metadata listing", {
-				workingDir: workingDir.replace(os.homedir(), "~"),
-				error: error instanceof Error ? error.message : String(error),
-			});
-		}
-
-		return {
-			workingDir,
-			targetLabel: technology ? technology.name : path.basename(workingDir),
-			...(technology?.repository ? { repository: technology.repository } : {}),
-			...(technology?.branch ? { branch: technology.branch } : {}),
-			outline: (await this.getRepoOutline(workingDir)) || "(outline unavailable)",
-			topLevelEntries,
-		};
-	}
-	/**
-	 * Execute query using RLM Orchestrator
-	 * This implements the multi-turn RLM pattern from the paper using RlmOrchestrator
-	 */
-	private async executeRlmQuery(query: string): Promise<RlmRunResult> {
-		const timingId = logger.timingStart("rlmQuery");
-
-		// Initialize orchestrator if not already done
-		if (!this.rlmOrchestrator) {
-			this.initializeRlmOrchestrator();
-		}
-
-		// Run the orchestrator with the query
-		const result = await this.rlmOrchestrator!.runDetailed(query);
-
-		logger.timingEnd(timingId, "AGENT", "RLM query completed");
-		return result;
-	}
+Remember that ALL tool calls MUST be executed using absolute path in \`${workingDir}\``
+      );
+      prompt = prompt.replace("</context_block>", "");
+    } else {
+      prompt = prompt.replace(
+        "<context_block>",
+        `You have been provided several related repositories to work with grouped in the following working directory: ${workingDir}
+
+Remember that ALL tool calls MUST be executed using absolute path in \`${workingDir}\``
+      );
+      prompt = prompt.replace("</context_block>", "");
+    }
+
+    logger.debug("AGENT", "Dynamic system prompt generated", {
+      hasTechnologyContext: !!technology,
+      promptLength: prompt.length,
+    });
+
+    return prompt;
+  }
+
+  private async createGeminiTempDir(): Promise<string> {
+    const tempDir = path.join(os.tmpdir(), `librarian-gemini-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+    return tempDir;
+  }
+
+  private async setupGeminiConfig(
+    tempDir: string,
+    systemPrompt: string,
+    _model: string
+  ): Promise<{ systemPromptPath: string; settingsPath: string }> {
+    const systemPromptPath = path.join(tempDir, "system.md");
+    const settingsPath = path.join(tempDir, "settings.json");
+
+    await Bun.write(systemPromptPath, systemPrompt);
+
+    const settings = {
+      tools: {
+        core: ["list_directory", "read_file", "glob", "search_file_content"],
+        autoAccept: true,
+      },
+      mcpServers: {},
+      mcp: {
+        excluded: ["*"],
+      },
+      experimental: {
+        enableAgents: false,
+      },
+      output: {
+        format: "json",
+      },
+    };
+    await Bun.write(settingsPath, JSON.stringify(settings, null, 2));
+
+    return { systemPromptPath, settingsPath };
+  }
+
+  private buildGeminiEnv(
+    tempDir: string,
+    model: string
+  ): Record<string, string | undefined> {
+    const settingsPath = path.join(tempDir, "settings.json");
+    const systemPromptPath = path.join(tempDir, "system.md");
+
+    return {
+      ...Bun.env,
+      GEMINI_SYSTEM_MD: systemPromptPath,
+      GEMINI_CLI_SYSTEM_DEFAULTS_PATH: settingsPath,
+      GEMINI_CLI_SYSTEM_SETTINGS_PATH: settingsPath,
+      GEMINI_MODEL: model,
+    };
+  }
+
+  private async cleanupGeminiTempDir(tempDir: string): Promise<void> {
+    try {
+      await rm(tempDir, { recursive: true, force: true });
+    } catch (err) {
+      logger.warn("AGENT", "Failed to cleanup Gemini temp files", {
+        error: err,
+      });
+    }
+  }
+
+  private async *streamClaudeCli(
+    query: string,
+    context?: AgentContext
+  ): AsyncGenerator<string, void, unknown> {
+    const workingDir = context?.workingDir || this.config.workingDir;
+    const systemPrompt = this.createDynamicSystemPrompt();
+
+    const args = [
+      "-p",
+      query,
+      "--system-prompt",
+      systemPrompt,
+      "--tools",
+      "Read,Glob,Grep",
+      "--dangerously-skip-permissions",
+      "--output-format",
+      "stream-json",
+    ];
+
+    const env = {
+      ...Bun.env,
+      CLAUDE_PROJECT_DIR: workingDir,
+      ...(this.config.aiProvider.model && {
+        ANTHROPIC_MODEL: this.config.aiProvider.model,
+      }),
+    };
+
+    logger.debug("AGENT", "Spawning Claude CLI", {
+      args: args.map((a) => (a.length > 100 ? `${a.substring(0, 100)}...` : a)),
+      workingDir,
+    });
+
+    const proc = Bun.spawn(["claude", ...args], {
+      cwd: workingDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    let buffer = "";
+
+    if (!proc.stdout) {
+      throw new Error("Failed to capture Claude CLI output");
+    }
+
+    const stderrPromise = proc.stderr
+      ? new Response(proc.stderr).text()
+      : Promise.resolve("");
+    const decoder = new TextDecoder();
+    const reader = proc.stdout.getReader();
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
+        }
+        try {
+          const data = JSON.parse(line);
+          // Filter for text content blocks in the stream
+          if (data.type === "text" && data.content) {
+            yield data.content;
+          } else if (data.type === "content_block_delta" && data.delta?.text) {
+            yield data.delta.text;
+          } else if (data.type === "message" && Array.isArray(data.content)) {
+            // Final message might come as a whole
+            for (const block of data.content) {
+              if (block.type === "text" && block.text) {
+                yield block.text;
+              }
+            }
+          }
+        } catch {
+          // Silent fail for non-JSON or partial lines
+        }
+      }
+    }
+
+    buffer += decoder.decode();
+    if (buffer.trim()) {
+      try {
+        const data = JSON.parse(buffer);
+        // Handle trailing partial line if the stream didn't end with newline
+        if (data.type === "text" && data.content) {
+          yield data.content;
+        } else if (data.type === "content_block_delta" && data.delta?.text) {
+          yield data.delta.text;
+        } else if (data.type === "message" && Array.isArray(data.content)) {
+          for (const block of data.content) {
+            if (block.type === "text" && block.text) {
+              yield block.text;
+            }
+          }
+        }
+      } catch {
+        // Ignore non-JSON trailing log lines emitted by claude CLI.
+      }
+    }
+
+    const [exitCode, stderrOutput] = await Promise.all([
+      proc.exited,
+      stderrPromise,
+    ]);
+    if (exitCode !== 0) {
+      const stderrPreview = stderrOutput.trim().slice(0, 500);
+      throw new Error(
+        stderrPreview
+          ? `Claude CLI exited with code ${exitCode}: ${stderrPreview}`
+          : `Claude CLI exited with code ${exitCode}`
+      );
+    }
+  }
+
+  private async *streamGeminiCli(
+    query: string,
+    context?: AgentContext
+  ): AsyncGenerator<string, void, unknown> {
+    const workingDir = context?.workingDir || this.config.workingDir;
+    const systemPrompt = this.createDynamicSystemPrompt();
+
+    const tempDir = await this.createGeminiTempDir();
+    const model = this.config.aiProvider.model || "gemini-2.5-flash";
+
+    try {
+      await this.setupGeminiConfig(tempDir, systemPrompt, model);
+
+      const args = [
+        "gemini",
+        "-p",
+        query,
+        "--output-format",
+        "stream-json",
+        "--yolo",
+      ];
+
+      const env = this.buildGeminiEnv(tempDir, model);
+
+      logger.debug("AGENT", "Spawning Gemini CLI", {
+        args,
+        workingDir,
+        model,
+      });
+
+      const proc = Bun.spawn(args, {
+        cwd: workingDir,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const reader = proc.stdout.getReader();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+
+        buffer += new TextDecoder().decode(value);
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (!line.trim()) {
+            continue;
+          }
+          try {
+            const data = JSON.parse(line);
+            const text = this.parseGeminiStreamLine(data);
+            if (text) {
+              yield text;
+            }
+          } catch {
+            // Silent fail for non-JSON or partial lines
+          }
+        }
+      }
+
+      const exitCode = await proc.exited;
+      if (exitCode !== 0) {
+        throw new Error(`Gemini CLI exited with code ${exitCode}`);
+      }
+    } finally {
+      await this.cleanupGeminiTempDir(tempDir);
+    }
+  }
+
+  private parseGeminiStreamLine(data: unknown): string | null {
+    if (
+      data &&
+      typeof data === "object" &&
+      "type" in data &&
+      "role" in data &&
+      "content" in data
+    ) {
+      const typedData = data as { type: string; role: string; content: string };
+      if (
+        typedData.type === "message" &&
+        typedData.role === "assistant" &&
+        typedData.content
+      ) {
+        return typedData.content;
+      }
+    }
+    return null;
+  }
+
+  private isCliProvider(): boolean {
+    return (
+      this.config.aiProvider.type === "claude-code" ||
+      this.config.aiProvider.type === "gemini-cli"
+    );
+  }
+
+  async initialize(): Promise<void> {
+    if (this.isCliProvider()) {
+      logger.info(
+        "AGENT",
+        `${this.config.aiProvider.type} CLI mode initialized`
+      );
+      return;
+    }
+
+    if (this.config.aiProvider.type === "codex-sdk") {
+      logger.info("AGENT", "Codex SDK mode initialized");
+      return;
+    }
+
+    logger.info("AGENT", "Direct RLM mode initialized", {
+      hasContextSchema: !!this.contextSchema,
+    });
+  }
+
+  /**
+   * Query repository with a given query and optional context
+   *
+   * @param repoPath - The repository path (deprecated, for compatibility)
+   * @param query - The query string
+   * @param context - Optional context object containing working directory and metadata
+   * @returns The agent's response as a string
+   */
+  async queryRepository(
+    _repoPath: string,
+    query: string,
+    context?: AgentContext
+  ): Promise<string> {
+    logger.info("AGENT", "Query started", {
+      queryLength: query.length,
+      hasContext: !!context,
+    });
+
+    // Use RLM mode for supported providers (not CLI-based ones)
+    if (this.shouldUseRlm()) {
+      logger.info("AGENT", "Using RLM mode");
+      const result = await this.executeRlmQuery(query);
+      logger.info("AGENT", "RLM query result received", {
+        root_iterations: result.stats.rootIterations,
+        sub_rlm_calls: result.stats.subRlmCalls,
+        sub_model_calls: result.stats.subModelCalls,
+        repo_calls: result.stats.repoCalls,
+        total_input_chars: result.stats.totalInputChars,
+        total_output_chars: result.stats.totalOutputChars,
+        final_set: result.stats.finalSet,
+        fallback_recovery_used: result.stats.fallbackRecoveryUsed,
+        metadata_history_entries: result.metadataHistory.length,
+        last_error:
+          result.metadataHistory[result.metadataHistory.length - 1]?.environment
+            .error?.message ?? null,
+      });
+      return result.answer;
+    }
+
+    if (this.config.aiProvider.type === "claude-code") {
+      let fullContent = "";
+      for await (const chunk of this.streamClaudeCli(query, context)) {
+        fullContent += chunk;
+      }
+      return fullContent;
+    }
+
+    if (this.config.aiProvider.type === "gemini-cli") {
+      let fullContent = "";
+      for await (const chunk of this.streamGeminiCli(query, context)) {
+        fullContent += chunk;
+      }
+      return fullContent;
+    }
+
+    if (this.config.aiProvider.type === "codex-sdk") {
+      let fullContent = "";
+      for await (const chunk of this.streamCodexSdk(query, context)) {
+        fullContent += chunk;
+      }
+      return fullContent;
+    }
+
+    throw new Error(
+      `Unsupported AI provider for direct repository query: ${this.config.aiProvider.type}`
+    );
+  }
+
+  /**
+   * Check if RLM mode should be used based on provider type
+   * RLM mode is used for API-based providers (OpenAI, Anthropic, Google)
+   * CLI/SDK providers (claude-code, gemini-cli, codex-sdk) use their own execution path
+   */
+  private shouldUseRlm(): boolean {
+    const rlmProviders = [
+      "openai",
+      "anthropic",
+      "google",
+      "openai-compatible",
+      "anthropic-compatible",
+    ];
+    return rlmProviders.includes(this.config.aiProvider.type);
+  }
+
+  private async *streamCodexSdk(
+    query: string,
+    context?: AgentContext
+  ): AsyncGenerator<string, void, unknown> {
+    const workingDir = context?.workingDir || this.config.workingDir;
+    const systemPrompt = this.createDynamicSystemPrompt();
+
+    logger.debug("AGENT", "Starting Codex SDK stream", {
+      workingDir,
+      model: this.config.aiProvider.model || "sdk-default",
+      queryLength: query.length,
+      systemPromptLength: systemPrompt.length,
+      sandboxMode: "read-only",
+    });
+
+    yield* streamCodexSdk({
+      workingDir: this.config.workingDir,
+      query,
+      systemPrompt,
+      aiProvider: this.config.aiProvider,
+      ...(context ? { context } : {}),
+    });
+  }
+
+  /**
+   * Initialize the RLM orchestrator on first use
+   */
+  private initializeRlmOrchestrator(): void {
+    const llmConfig: LlmConfig = {
+      type: this.config.aiProvider.type as LlmConfig["type"],
+      apiKey: this.config.aiProvider.apiKey,
+      model: this.config.aiProvider.model,
+      baseURL: this.config.aiProvider.baseURL,
+    };
+
+    const orchestratorConfig: RlmOrchestratorConfig = {
+      llmConfig,
+      rootMetadataLoader: () => this.loadRootMetadata(),
+      workingDir: this.config.workingDir,
+      maxIterations: 30,
+      stdoutPreviewLength: 2000,
+      systemPrompt: this.createRlmSystemPrompt(),
+    };
+
+    this.rlmOrchestrator = new RlmOrchestrator(orchestratorConfig);
+    logger.info("AGENT", "RLM Orchestrator initialized", {
+      workingDir: this.config.workingDir,
+      maxIterations: orchestratorConfig.maxIterations,
+    });
+  }
+
+  private async loadRootMetadata(): Promise<RootRepoMetadata> {
+    const { workingDir, technology } = this.config;
+    let topLevelEntries: RootRepoMetadata["topLevelEntries"] = [];
+
+    try {
+      const rawListing = await listTool.invoke(
+        {
+          directoryPath: ".",
+          recursive: false,
+          maxDepth: 1,
+          includeHidden: false,
+        },
+        { context: { workingDir, group: "", technology: "" } }
+      );
+      const listing = JSON.parse(rawListing) as {
+        entries?: Array<{
+          name: string;
+          path: string;
+          isDirectory: boolean;
+          size?: number;
+          lineCount?: number;
+          depth?: number;
+        }>;
+        error?: unknown;
+        message?: unknown;
+      };
+
+      if (!Array.isArray(listing.entries)) {
+        logger.warn("AGENT", "Root metadata listing returned no entries", {
+          workingDir: workingDir.replace(os.homedir(), "~"),
+          ...(typeof listing.message === "string"
+            ? { message: listing.message }
+            : {}),
+        });
+      } else {
+        topLevelEntries = listing.entries.map((entry) => ({
+          name: entry.name,
+          path: entry.path,
+          isDirectory: entry.isDirectory,
+          ...(entry.size !== undefined ? { size: entry.size } : {}),
+          ...(entry.lineCount !== undefined
+            ? { lineCount: entry.lineCount }
+            : {}),
+          ...(entry.depth !== undefined ? { depth: entry.depth } : {}),
+        }));
+      }
+    } catch (error) {
+      logger.warn("AGENT", "Failed to load root metadata listing", {
+        workingDir: workingDir.replace(os.homedir(), "~"),
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    return {
+      workingDir,
+      targetLabel: technology ? technology.name : path.basename(workingDir),
+      ...(technology?.repository ? { repository: technology.repository } : {}),
+      ...(technology?.branch ? { branch: technology.branch } : {}),
+      outline:
+        (await this.getRepoOutline(workingDir)) || "(outline unavailable)",
+      topLevelEntries,
+    };
+  }
+  /**
+   * Execute query using RLM Orchestrator
+   * This implements the multi-turn RLM pattern from the paper using RlmOrchestrator
+   */
+  private async executeRlmQuery(query: string): Promise<RlmRunResult> {
+    const timingId = logger.timingStart("rlmQuery");
+
+    // Initialize orchestrator if not already done
+    if (!this.rlmOrchestrator) {
+      this.initializeRlmOrchestrator();
+    }
+
+    // Run the orchestrator with the query
+    const result = await this.rlmOrchestrator!.runDetailed(query);
+
+    logger.timingEnd(timingId, "AGENT", "RLM query completed");
+    return result;
+  }
 
   /**
    * Stream repository query with optional context
@@ -1175,42 +859,42 @@ notifications = false
    * @param context - Optional context object containing working directory and metadata
    * @returns Async generator yielding token-by-token chunks from the LLM
    */
-	async *streamRepository(
-		_repoPath: string,
-		query: string,
-		context?: AgentContext,
-	): AsyncGenerator<string, void, unknown> {
-		logger.info("AGENT", "Stream started", {
-			queryLength: query.length,
-			hasContext: !!context,
-		});
+  async *streamRepository(
+    _repoPath: string,
+    query: string,
+    context?: AgentContext
+  ): AsyncGenerator<string, void, unknown> {
+    logger.info("AGENT", "Stream started", {
+      queryLength: query.length,
+      hasContext: !!context,
+    });
 
-		if (this.config.aiProvider.type === "claude-code") {
-			yield* this.streamClaudeCli(query, context);
-			return;
-		}
+    if (this.config.aiProvider.type === "claude-code") {
+      yield* this.streamClaudeCli(query, context);
+      return;
+    }
 
-		if (this.config.aiProvider.type === "gemini-cli") {
-			yield* this.streamGeminiCli(query, context);
-			return;
-		}
+    if (this.config.aiProvider.type === "gemini-cli") {
+      yield* this.streamGeminiCli(query, context);
+      return;
+    }
 
-		if (this.config.aiProvider.type === "codex-cli") {
-			yield* this.streamCodexCli(query, context);
-			return;
-		}
+    if (this.config.aiProvider.type === "codex-sdk") {
+      yield* this.streamCodexSdk(query, context);
+      return;
+    }
 
-		// API-backed providers stream through the direct orchestrator path.
-		if (this.shouldUseRlm()) {
-			// For RLM mode, yield progress indicator then execute and return final result
-			yield "Exploring repository...\n";
-			const result = await this.queryRepository(_repoPath, query, context);
-			yield result;
-			return;
-		}
+    // API-backed providers stream through the direct orchestrator path.
+    if (this.shouldUseRlm()) {
+      // For RLM mode, yield progress indicator then execute and return final result
+      yield "Exploring repository...\n";
+      const result = await this.queryRepository(_repoPath, query, context);
+      yield result;
+      return;
+    }
 
-		throw new Error(
-			`Unsupported AI provider for streaming query: ${this.config.aiProvider.type}`,
-		);
-	}
+    throw new Error(
+      `Unsupported AI provider for streaming query: ${this.config.aiProvider.type}`
+    );
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { parse, stringify } from "yaml";
 import { z } from "zod";
+import { parseCodexModelSelection } from "./agents/codex-sdk-adapter.js";
 import type { LibrarianConfig } from "./index.js";
 import { logger } from "./utils/logger.js";
 import { expandTilde } from "./utils/path-utils.js";
@@ -29,7 +30,7 @@ const ConfigSchema = z.object({
         "anthropic-compatible",
         "claude-code",
         "gemini-cli",
-        "codex-cli",
+        "codex-sdk",
       ]),
       apiKey: z.string().optional(), // Optional - will be loaded from .env or not needed for CLI providers
       model: z.string().optional(),
@@ -46,7 +47,7 @@ const ConfigSchema = z.object({
       "anthropic-compatible",
       "claude-code",
       "gemini-cli",
-      "codex-cli",
+      "codex-sdk",
     ])
     .optional(),
   llm_model: z.string().optional(),
@@ -119,7 +120,7 @@ function validateApiKey(
   const isCliProvider =
     config.aiProvider.type === "claude-code" ||
     config.aiProvider.type === "gemini-cli" ||
-    config.aiProvider.type === "codex-cli";
+    config.aiProvider.type === "codex-sdk";
   if (
     !isCliProvider &&
     (!config.aiProvider.apiKey || config.aiProvider.apiKey.trim() === "")
@@ -174,6 +175,26 @@ function validateBaseUrlForCompatibleProviders(
         "Validation failed: model missing for anthropic-compatible provider"
       );
     }
+  }
+}
+
+function validateCodexModelSelection(
+  config: LibrarianConfig,
+  errors: string[]
+): void {
+  if (config.aiProvider.type !== "codex-sdk") {
+    return;
+  }
+
+  try {
+    parseCodexModelSelection(config.aiProvider.model);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    errors.push(message);
+    logger.debug("CONFIG", "Validation failed: invalid Codex model string", {
+      model: config.aiProvider.model,
+      error: message,
+    });
   }
 }
 
@@ -258,6 +279,7 @@ function validateConfig(config: LibrarianConfig, envPath: string): void {
 
   validateApiKey(config, envPath, errors);
   validateBaseUrlForCompatibleProviders(config, errors);
+  validateCodexModelSelection(config, errors);
   validateReposPath(config, errors);
   validateTechnologies(config, errors);
 
@@ -291,6 +313,28 @@ function normalizeTechnologies(
   return technologies;
 }
 
+function buildLibrarianTechnologies(
+  technologies: TechnologiesType
+): LibrarianConfig["technologies"] {
+  if (!technologies) {
+    return { default: {} };
+  }
+
+  const result: LibrarianConfig["technologies"] = {};
+  for (const [groupName, group] of Object.entries(technologies)) {
+    result[groupName] = {};
+    for (const [techName, tech] of Object.entries(group)) {
+      result[groupName][techName] = {
+        repo: tech.repo ?? "",
+        branch: tech.branch,
+        ...(tech.description ? { description: tech.description } : {}),
+      };
+    }
+  }
+
+  return result;
+}
+
 function buildAiProvider(
   validatedConfig: z.infer<typeof ConfigSchema>,
   envVars: Record<string, string>
@@ -300,7 +344,11 @@ function buildAiProvider(
     return {
       type,
       apiKey:
-        validatedConfig.aiProvider.apiKey || envVars.LIBRARIAN_API_KEY || "",
+        type === "codex-sdk"
+          ? ""
+          : validatedConfig.aiProvider.apiKey ||
+            envVars.LIBRARIAN_API_KEY ||
+            "",
       ...(model && { model }),
       ...(baseURL && { baseURL }),
     };
@@ -310,7 +358,10 @@ function buildAiProvider(
     logger.debug("CONFIG", "Using README-style llm_* keys for AI provider");
     return {
       type: validatedConfig.llm_provider,
-      apiKey: envVars.LIBRARIAN_API_KEY || "",
+      apiKey:
+        validatedConfig.llm_provider === "codex-sdk"
+          ? ""
+          : envVars.LIBRARIAN_API_KEY || "",
       ...(validatedConfig.llm_model && { model: validatedConfig.llm_model }),
       ...(validatedConfig.base_url && { baseURL: validatedConfig.base_url }),
     };
@@ -370,7 +421,9 @@ export async function loadConfig(
   const validatedConfig = ConfigSchema.parse(parsedConfig);
   logger.debug("CONFIG", "Config schema validation passed");
 
-  const technologies = normalizeTechnologies(validatedConfig.technologies);
+  const technologies = buildLibrarianTechnologies(
+    normalizeTechnologies(validatedConfig.technologies)
+  );
   const aiProvider = buildAiProvider(validatedConfig, envVars);
 
   logger.debug("CONFIG", "API key source", {
@@ -378,15 +431,14 @@ export async function loadConfig(
     fromConfig: !!validatedConfig.aiProvider?.apiKey,
   });
 
-  const config = {
-    ...validatedConfig,
-    technologies: technologies || { default: {} },
+  const config: LibrarianConfig = {
+    technologies,
     aiProvider,
-    repos_path: validatedConfig.repos_path
-      ? expandTilde(validatedConfig.repos_path)
-      : undefined,
     workingDir: expandTilde(validatedConfig.workingDir),
-  } as LibrarianConfig;
+    ...(validatedConfig.repos_path
+      ? { repos_path: expandTilde(validatedConfig.repos_path) }
+      : {}),
+  };
 
   validateConfig(config, envPath);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export interface LibrarianConfig {
       | "anthropic-compatible"
       | "claude-code"
       | "gemini-cli"
-      | "codex-cli";
+      | "codex-sdk";
     apiKey: string;
     model?: string;
     baseURL?: string;
@@ -45,7 +45,7 @@ export class Librarian {
 
   constructor(config: LibrarianConfig) {
     // Validate AI provider type
-    const validProviderTypes = [
+    const validProviderTypes = new Set<string>([
       "openai",
       "anthropic",
       "google",
@@ -53,13 +53,10 @@ export class Librarian {
       "anthropic-compatible",
       "claude-code",
       "gemini-cli",
-      "codex-cli",
-    ] as const;
-    type ValidProviderType = (typeof validProviderTypes)[number];
+      "codex-sdk",
+    ]);
 
-    if (
-      !validProviderTypes.includes(config.aiProvider.type as ValidProviderType)
-    ) {
+    if (!validProviderTypes.has(config.aiProvider.type)) {
       throw new Error(
         `Unsupported AI provider type: ${config.aiProvider.type}`
       );
@@ -78,16 +75,12 @@ export class Librarian {
   }
 
   async initialize(): Promise<void> {
-    const cliProviders = {
-      "claude-code": { command: "claude", displayName: "Claude" },
-      "gemini-cli": { command: "gemini", displayName: "Gemini" },
-      "codex-cli": { command: "codex", displayName: "Codex" },
-    } as const;
+    if (this.config.aiProvider.type === "claude-code") {
+      this.verifyCliProvider("claude", "claude-code", "Claude");
+    }
 
-    if (this.config.aiProvider.type in cliProviders) {
-      const providerType = this.config.aiProvider.type as keyof typeof cliProviders;
-      const { command, displayName } = cliProviders[providerType];
-      this.verifyCliProvider(command, providerType, displayName);
+    if (this.config.aiProvider.type === "gemini-cli") {
+      this.verifyCliProvider("gemini", "gemini-cli", "Gemini");
     }
 
     // Create working directory if it doesn't exist
@@ -107,9 +100,9 @@ export class Librarian {
   }
 
   private verifyCliProvider(
-    command: "claude" | "gemini" | "codex",
-    providerType: "claude-code" | "gemini-cli" | "codex-cli",
-    displayName: "Claude" | "Gemini" | "Codex"
+    command: "claude" | "gemini",
+    providerType: "claude-code" | "gemini-cli",
+    displayName: "Claude" | "Gemini"
   ): void {
     try {
       const result = Bun.spawnSync([command, "--version"], {

--- a/tests/ai-provider.test.ts
+++ b/tests/ai-provider.test.ts
@@ -84,13 +84,13 @@ describe("AI Provider Integration", () => {
       expect(librarian).toBeInstanceOf(Librarian);
     });
 
-    it("should support Codex CLI provider configuration", () => {
+    it("should support Codex SDK provider configuration", () => {
       const config: LibrarianConfig = {
         ...mockConfig,
         aiProvider: {
-          type: "codex-cli",
+          type: "codex-sdk",
           apiKey: "",
-          model: "gpt-5.3-codex",
+          model: "gpt-5.4:xhigh",
         },
       };
 

--- a/tests/codex-sdk-adapter.test.ts
+++ b/tests/codex-sdk-adapter.test.ts
@@ -90,6 +90,30 @@ describe("Codex SDK adapter", () => {
     }
   });
 
+  it("prefers the SDK-bundled Codex executable when available", () => {
+    const originalLibrarianCodexPath = Bun.env.LIBRARIAN_CODEX_PATH;
+    const originalCodexPath = Bun.env.CODEX_PATH;
+    Bun.env.LIBRARIAN_CODEX_PATH = undefined;
+    Bun.env.CODEX_PATH = undefined;
+
+    try {
+      const options = buildCodexSdkClientOptions(
+        {
+          apiKey: "",
+        },
+        "/tmp/instructions.md",
+        "/tmp/codex-home"
+      );
+
+      expect(options.codexPathOverride).toContain("node_modules");
+      expect(options.codexPathOverride).toContain("@openai");
+      expect(options.codexPathOverride).toContain("codex-");
+    } finally {
+      Bun.env.LIBRARIAN_CODEX_PATH = originalLibrarianCodexPath;
+      Bun.env.CODEX_PATH = originalCodexPath;
+    }
+  });
+
   it("builds an isolated SDK environment for the Codex child process", () => {
     const env = buildCodexSdkEnv("/tmp/isolated-codex-home");
 

--- a/tests/codex-sdk-adapter.test.ts
+++ b/tests/codex-sdk-adapter.test.ts
@@ -67,6 +67,29 @@ describe("Codex SDK adapter", () => {
     );
   });
 
+  it("allows an explicit system Codex executable override", () => {
+    const originalPath = Bun.env.LIBRARIAN_CODEX_PATH;
+    Bun.env.LIBRARIAN_CODEX_PATH = "/opt/codex/bin/codex";
+
+    try {
+      const options = buildCodexSdkClientOptions(
+        {
+          apiKey: "",
+        },
+        "/tmp/instructions.md",
+        "/tmp/codex-home"
+      );
+
+      expect(options.codexPathOverride).toBe("/opt/codex/bin/codex");
+    } finally {
+      if (originalPath) {
+        Bun.env.LIBRARIAN_CODEX_PATH = originalPath;
+      } else {
+        Bun.env.LIBRARIAN_CODEX_PATH = undefined;
+      }
+    }
+  });
+
   it("builds an isolated SDK environment for the Codex child process", () => {
     const env = buildCodexSdkEnv("/tmp/isolated-codex-home");
 

--- a/tests/codex-sdk-adapter.test.ts
+++ b/tests/codex-sdk-adapter.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "bun:test";
+import type {
+  CodexOptions,
+  ThreadEvent,
+  ThreadOptions,
+} from "@openai/codex-sdk";
+import {
+  buildCodexSdkClientOptions,
+  buildCodexSdkEnv,
+  buildCodexThreadOptions,
+  codexSdkEventText,
+  createCodexSdkTextStreamState,
+  parseCodexModelSelection,
+  streamCodexSdk,
+} from "../src/agents/codex-sdk-adapter.js";
+
+async function* events(
+  items: ThreadEvent[]
+): AsyncGenerator<ThreadEvent, void, unknown> {
+  await Promise.resolve();
+  for (const item of items) {
+    yield item;
+  }
+}
+
+describe("Codex SDK adapter", () => {
+  it("parses Codex model and reasoning effort suffixes", () => {
+    expect(parseCodexModelSelection("gpt-5.4:xhigh")).toEqual({
+      model: "gpt-5.4",
+      modelReasoningEffort: "xhigh",
+    });
+    expect(parseCodexModelSelection("gpt-5.4")).toEqual({
+      model: "gpt-5.4",
+    });
+    expect(parseCodexModelSelection(undefined)).toEqual({});
+  });
+
+  it("rejects malformed Codex model strings", () => {
+    expect(() => parseCodexModelSelection("gpt-5.4:ultra")).toThrow(
+      "Invalid Codex reasoning effort"
+    );
+    expect(() => parseCodexModelSelection(":high")).toThrow(
+      "Model name is required"
+    );
+    expect(() => parseCodexModelSelection("gpt-5.4:high:extra")).toThrow(
+      "Invalid Codex model string"
+    );
+  });
+
+  it("builds SDK client options without overriding Codex CLI auth", () => {
+    const options = buildCodexSdkClientOptions(
+      {
+        apiKey: "sk-test",
+        baseURL: "https://api.example.com/v1",
+      },
+      "/tmp/instructions.md",
+      "/tmp/codex-home"
+    );
+
+    expect(options.apiKey).toBeUndefined();
+    expect(options.baseUrl).toBe("https://api.example.com/v1");
+    expect(options.env?.CODEX_HOME).toBe("/tmp/codex-home");
+    expect(options.env?.CODEX_API_KEY).toBeUndefined();
+    expect(options.env?.OPENAI_API_KEY).toBeUndefined();
+    expect(options.config?.model_instructions_file).toBe(
+      "/tmp/instructions.md"
+    );
+  });
+
+  it("builds an isolated SDK environment for the Codex child process", () => {
+    const env = buildCodexSdkEnv("/tmp/isolated-codex-home");
+
+    expect(env.CODEX_HOME).toBe("/tmp/isolated-codex-home");
+    expect(env.CODEX_API_KEY).toBeUndefined();
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.LIBRARIAN_API_KEY).toBeUndefined();
+  });
+
+  it("builds read-only SDK thread options and omits model fields when unset", () => {
+    const options = buildCodexThreadOptions({ apiKey: "" }, "/repo");
+
+    expect(options.model).toBeUndefined();
+    expect(options.modelReasoningEffort).toBeUndefined();
+    expect(options.workingDirectory).toBe("/repo");
+    expect(options.sandboxMode).toBe("read-only");
+    expect(options.approvalPolicy).toBe("untrusted");
+    expect(options.webSearchEnabled).toBe(false);
+    expect(options.webSearchMode).toBe("disabled");
+    expect(options.networkAccessEnabled).toBe(false);
+  });
+
+  it("extracts agent messages from SDK events", () => {
+    const text = codexSdkEventText({
+      type: "item.completed",
+      item: {
+        id: "item-1",
+        type: "agent_message",
+        text: "hello from codex",
+      },
+    });
+
+    expect(text).toBe("hello from codex");
+  });
+
+  it("emits only appended text for updated agent message events", () => {
+    const state = createCodexSdkTextStreamState();
+
+    const first = codexSdkEventText(
+      {
+        type: "item.updated",
+        item: {
+          id: "item-1",
+          type: "agent_message",
+          text: "hello",
+        },
+      },
+      state
+    );
+    const second = codexSdkEventText(
+      {
+        type: "item.updated",
+        item: {
+          id: "item-1",
+          type: "agent_message",
+          text: "hello world",
+        },
+      },
+      state
+    );
+    const completed = codexSdkEventText(
+      {
+        type: "item.completed",
+        item: {
+          id: "item-1",
+          type: "agent_message",
+          text: "hello world",
+        },
+      },
+      state
+    );
+
+    expect([first, second, completed]).toEqual(["hello", " world", null]);
+  });
+
+  it("throws for SDK failure events", () => {
+    expect(() =>
+      codexSdkEventText({
+        type: "turn.failed",
+        error: { message: "model refused" },
+      })
+    ).toThrow("Codex SDK turn failed: model refused");
+
+    expect(() =>
+      codexSdkEventText({
+        type: "error",
+        message: "stream ended",
+      })
+    ).toThrow("Codex SDK stream failed: stream ended");
+  });
+
+  it("streams fake SDK events through the adapter", async () => {
+    let clientOptions: CodexOptions | undefined;
+    let threadOptions: ThreadOptions | undefined;
+    let prompt: string | undefined;
+
+    const chunks: string[] = [];
+    for await (const chunk of streamCodexSdk({
+      workingDir: "/repo",
+      query: "Explain the code",
+      systemPrompt: "Investigate with citations.",
+      aiProvider: {
+        apiKey: "sk-test",
+        model: "gpt-5.4:xhigh",
+        baseURL: "https://api.example.com/v1",
+      },
+      runtimeFilesFactory: () =>
+        Promise.resolve({
+          tempDir: "/tmp/librarian-codex-sdk-test",
+          instructionsPath: "/tmp/librarian-codex-sdk-test/instructions.md",
+          codexHome: "/tmp/librarian-codex-sdk-test/.codex-home",
+        }),
+      cleanupRuntimeFiles: () => Promise.resolve(),
+      clientFactory: (options) => {
+        clientOptions = options;
+        return {
+          startThread: (optionsForThread) => {
+            threadOptions = optionsForThread;
+            return {
+              runStreamed: (input) => {
+                prompt = input;
+                return Promise.resolve({
+                  events: events([
+                    {
+                      type: "item.updated",
+                      item: {
+                        id: "item-1",
+                        type: "agent_message",
+                        text: "partial",
+                      },
+                    },
+                    {
+                      type: "item.completed",
+                      item: {
+                        id: "item-1",
+                        type: "agent_message",
+                        text: "partial answer",
+                      },
+                    },
+                    {
+                      type: "item.completed",
+                      item: {
+                        id: "item-2",
+                        type: "agent_message",
+                        text: " plus follow-up",
+                      },
+                    },
+                  ]),
+                });
+              },
+            };
+          },
+        };
+      },
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["partial", " answer", "\n plus follow-up"]);
+    expect(prompt).toBe("Explain the code");
+    expect(clientOptions?.apiKey).toBeUndefined();
+    expect(clientOptions?.baseUrl).toBe("https://api.example.com/v1");
+    expect(clientOptions?.env?.CODEX_HOME).toBe(
+      "/tmp/librarian-codex-sdk-test/.codex-home"
+    );
+    expect(threadOptions?.model).toBe("gpt-5.4");
+    expect(threadOptions?.modelReasoningEffort).toBe("xhigh");
+    expect(threadOptions?.workingDirectory).toBe("/repo");
+  });
+});

--- a/tests/config-schema.test.ts
+++ b/tests/config-schema.test.ts
@@ -114,20 +114,24 @@ describe("Config Schema Alignment", () => {
 
     const originalExit = process.exit;
     const originalError = console.error;
-    process.exit = ((code?: number) => {
+    const exitWithThrow: typeof process.exit = (code) => {
       throw new Error(`process.exit:${code ?? 0}`);
-    }) as typeof process.exit;
-    console.error = (() => undefined) as typeof console.error;
+    };
+    const noopError: typeof console.error = () => undefined;
+    process.exit = exitWithThrow;
+    console.error = noopError;
 
     try {
-      await expect(loadConfig(TEST_CONFIG_PATH)).rejects.toThrow("process.exit:1");
+      await expect(loadConfig(TEST_CONFIG_PATH)).rejects.toThrow(
+        "process.exit:1"
+      );
     } finally {
       process.exit = originalExit;
       console.error = originalError;
     }
   });
 
-  it("should support codex-cli provider without API key", async () => {
+  it("should support codex-sdk provider without API key", async () => {
     const newConfig = {
       technologies: {
         default: {
@@ -136,8 +140,8 @@ describe("Config Schema Alignment", () => {
       },
       repos_path: "./libs",
       aiProvider: {
-        type: "codex-cli",
-        model: "gpt-5.3-codex",
+        type: "codex-sdk",
+        model: "gpt-5.4:xhigh",
       },
     };
 
@@ -145,9 +149,111 @@ describe("Config Schema Alignment", () => {
 
     const loaded: any = await loadConfig(TEST_CONFIG_PATH);
 
-    expect(loaded.aiProvider?.type).toBe("codex-cli");
-    expect(loaded.aiProvider?.model).toBe("gpt-5.3-codex");
+    expect(loaded.aiProvider?.type).toBe("codex-sdk");
+    expect(loaded.aiProvider?.model).toBe("gpt-5.4:xhigh");
     expect(loaded.aiProvider?.apiKey).toBe("");
+  });
+
+  it("should not translate Librarian API keys into codex-sdk auth", async () => {
+    const newConfig = {
+      technologies: {
+        default: {
+          demo: { repo: "http://example.com" },
+        },
+      },
+      repos_path: "./libs",
+      aiProvider: {
+        type: "codex-sdk",
+        apiKey: "sk-config-key",
+        model: "gpt-5.4:xhigh",
+      },
+    };
+
+    fs.writeFileSync(TEST_CONFIG_PATH, stringify(newConfig));
+    fs.writeFileSync(TEST_ENV_PATH, "LIBRARIAN_API_KEY=sk-env-key");
+
+    const loaded: any = await loadConfig(TEST_CONFIG_PATH);
+
+    expect(loaded.aiProvider?.type).toBe("codex-sdk");
+    expect(loaded.aiProvider?.apiKey).toBe("");
+  });
+
+  it("should support codex-sdk provider with a plain model", async () => {
+    const newConfig = {
+      technologies: {
+        default: {
+          demo: { repo: "http://example.com" },
+        },
+      },
+      repos_path: "./libs",
+      aiProvider: {
+        type: "codex-sdk",
+        model: "gpt-5.4",
+      },
+    };
+
+    fs.writeFileSync(TEST_CONFIG_PATH, stringify(newConfig));
+
+    const loaded: any = await loadConfig(TEST_CONFIG_PATH);
+
+    expect(loaded.aiProvider?.type).toBe("codex-sdk");
+    expect(loaded.aiProvider?.model).toBe("gpt-5.4");
+  });
+
+  it("should support codex-sdk provider with omitted model", async () => {
+    const newConfig = {
+      technologies: {
+        default: {
+          demo: { repo: "http://example.com" },
+        },
+      },
+      repos_path: "./libs",
+      aiProvider: {
+        type: "codex-sdk",
+      },
+    };
+
+    fs.writeFileSync(TEST_CONFIG_PATH, stringify(newConfig));
+
+    const loaded: any = await loadConfig(TEST_CONFIG_PATH);
+
+    expect(loaded.aiProvider?.type).toBe("codex-sdk");
+    expect(loaded.aiProvider?.model).toBeUndefined();
+  });
+
+  it("should reject malformed codex-sdk model suffixes", async () => {
+    const newConfig = {
+      technologies: {
+        default: {
+          demo: { repo: "http://example.com" },
+        },
+      },
+      repos_path: "./libs",
+      aiProvider: {
+        type: "codex-sdk",
+        model: "gpt-5.4:ultra",
+      },
+    };
+
+    fs.writeFileSync(TEST_CONFIG_PATH, stringify(newConfig));
+
+    const originalExit = process.exit;
+    const originalError = console.error;
+    const exitWithThrow: typeof process.exit = (code) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+    };
+    const noopError: typeof console.error = () => undefined;
+    process.exit = exitWithThrow;
+    console.error = noopError;
+
+    try {
+      await expect(loadConfig(TEST_CONFIG_PATH)).rejects.toThrow(
+        "process.exit:1"
+      );
+    } finally {
+      process.exit = originalExit;
+      console.error = originalError;
+    }
   });
 
   it("should auto-create default config when file missing", async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -59,14 +59,14 @@ describe("Configuration", () => {
         "anthropic",
         "google",
         "openai-compatible",
-        "codex-cli",
+        "codex-sdk",
       ]).toContain(config.llm_provider);
     });
 
     it("should support all LLM providers", () => {
       const providers: Array<
-        "openai" | "anthropic" | "google" | "openai-compatible" | "codex-cli"
-      > = ["openai", "anthropic", "google", "openai-compatible", "codex-cli"];
+        "openai" | "anthropic" | "google" | "openai-compatible" | "codex-sdk"
+      > = ["openai", "anthropic", "google", "openai-compatible", "codex-sdk"];
 
       for (const provider of providers) {
         const config = createReadmeAlignedConfig({ llm_provider: provider });

--- a/tests/helpers/test-config.ts
+++ b/tests/helpers/test-config.ts
@@ -27,7 +27,7 @@ export interface ReadmeConfig {
     | "anthropic"
     | "google"
     | "openai-compatible"
-    | "codex-cli";
+    | "codex-sdk";
   llm_model?: string;
   base_url?: string;
 }

--- a/tests/rlm-agent-integration.test.ts
+++ b/tests/rlm-agent-integration.test.ts
@@ -129,7 +129,9 @@ describe("ReactAgent RLM integration", () => {
 
       await agent.initialize();
 
-      expect((agent as unknown as { rlmOrchestrator?: unknown }).rlmOrchestrator).toBeUndefined();
+      expect(
+        (agent as unknown as { rlmOrchestrator?: unknown }).rlmOrchestrator
+      ).toBeUndefined();
     });
 
     it("should create the direct orchestrator on first non-CLI use", () => {
@@ -138,9 +140,13 @@ describe("ReactAgent RLM integration", () => {
         workingDir: "/test/repo",
       });
 
-      (agent as unknown as { initializeRlmOrchestrator: () => void }).initializeRlmOrchestrator();
+      (
+        agent as unknown as { initializeRlmOrchestrator: () => void }
+      ).initializeRlmOrchestrator();
 
-      expect((agent as unknown as { rlmOrchestrator?: unknown }).rlmOrchestrator).toBeDefined();
+      expect(
+        (agent as unknown as { rlmOrchestrator?: unknown }).rlmOrchestrator
+      ).toBeDefined();
     });
 
     it("should keep claude-code on the CLI path", async () => {
@@ -151,7 +157,9 @@ describe("ReactAgent RLM integration", () => {
 
       await agent.initialize();
 
-      expect((agent as unknown as { rlmOrchestrator?: unknown }).rlmOrchestrator).toBeUndefined();
+      expect(
+        (agent as unknown as { rlmOrchestrator?: unknown }).rlmOrchestrator
+      ).toBeUndefined();
     });
 
     it("should keep gemini-cli on the CLI path", async () => {
@@ -162,18 +170,22 @@ describe("ReactAgent RLM integration", () => {
 
       await agent.initialize();
 
-      expect((agent as unknown as { rlmOrchestrator?: unknown }).rlmOrchestrator).toBeUndefined();
+      expect(
+        (agent as unknown as { rlmOrchestrator?: unknown }).rlmOrchestrator
+      ).toBeUndefined();
     });
 
-    it("should keep codex-cli on the CLI path", async () => {
+    it("should keep codex-sdk off the RLM path", async () => {
       const agent = new ReactAgent({
-        aiProvider: { type: "codex-cli", apiKey: "" },
+        aiProvider: { type: "codex-sdk", apiKey: "" },
         workingDir: "/test/repo",
       });
 
       await agent.initialize();
 
-      expect((agent as unknown as { rlmOrchestrator?: unknown }).rlmOrchestrator).toBeUndefined();
+      expect(
+        (agent as unknown as { rlmOrchestrator?: unknown }).rlmOrchestrator
+      ).toBeUndefined();
     });
   });
 
@@ -188,7 +200,7 @@ describe("ReactAgent RLM integration", () => {
       let callCount = 0;
       (listTool as { invoke: typeof listTool.invoke }).invoke = async (
         input,
-        config,
+        config
       ) => {
         callCount += 1;
         if (callCount === 1) {
@@ -211,7 +223,8 @@ describe("ReactAgent RLM integration", () => {
         expect(metadata.topLevelEntries).toEqual([]);
         expect(metadata.outline).toBe("(outline unavailable)");
       } finally {
-        (listTool as { invoke: typeof listTool.invoke }).invoke = originalInvoke;
+        (listTool as { invoke: typeof listTool.invoke }).invoke =
+          originalInvoke;
       }
     });
 
@@ -259,7 +272,8 @@ describe("ReactAgent RLM integration", () => {
         expect(metadata.topLevelEntries).toEqual([]);
         expect(metadata.outline).toBe("[DIR] src");
       } finally {
-        (listTool as { invoke: typeof listTool.invoke }).invoke = originalInvoke;
+        (listTool as { invoke: typeof listTool.invoke }).invoke =
+          originalInvoke;
       }
     });
   });
@@ -341,8 +355,9 @@ describe("ReactAgent RLM integration", () => {
 
         expect(result).toBe("done");
         expect(
-          logEntries.find((entry) => entry.message === "RLM query result received")
-            ?.metadata,
+          logEntries.find(
+            (entry) => entry.message === "RLM query result received"
+          )?.metadata
         ).toEqual({
           root_iterations: 3,
           sub_rlm_calls: 2,


### PR DESCRIPTION
## Summary
- Replace the old Librarian-owned Codex CLI execution path with a Codex SDK adapter and rename the provider to codex-sdk.
- Parse inline Codex reasoning effort suffixes such as gpt-5.4:xhigh while leaving omitted models to SDK defaults.
- Keep Codex SDK auth isolated but aligned with the system codex CLI by copying local Codex auth into a temporary CODEX_HOME and passing a sanitized environment.
- Stream all Codex SDK agent-message content across item.started, item.updated, and item.completed events without truncating after the first event or duplicating completed text.
- Update docs, config schemas, provider tests, dependency lockfiles, and Nix dependency metadata.

## Scope Notes
- codex-cli is intentionally removed as a supported provider name; configs should use codex-sdk.
- codex-sdk does not translate apiKey or LIBRARIAN_API_KEY into SDK auth, so other provider keys cannot override local Codex CLI auth.
- SDK 0.128.0 does not expose the old --ephemeral flag; this sets history.persistence = none where supported while preserving isolated runtime files.

## Validation
- bun run build:dev
- bun test tests/codex-sdk-adapter.test.ts
- bun run test (418 passing)
- bun run build
- ./librarian explore --tech cbor-x-source with complex real queries
- nix build .#default
- ./result/bin/librarian --help